### PR TITLE
refactor(tf-kubeadm): Integrate Kubernetes Add-ons with Bootstrapper Harbor and Standardize State Management. Stage III

### DIFF
--- a/terraform/layers/20-security-pki/outputs.tf
+++ b/terraform/layers/20-security-pki/outputs.tf
@@ -41,7 +41,10 @@ output "auth_backend_paths" {
   value       = module.vault_pki_setup.auth_backend_paths
 }
 
-output "bootstrap_ca_path" {
-  description = "Path to the bootstrap CA certificate (written by Layer 10)"
-  value       = local.bootstrap_ca_path
+output "bootstrap_ca" {
+  description = "Bootstrap CA certificate details"
+  value = {
+    path    = local.bootstrap_ca_path
+    content = file(local.bootstrap_ca_path)
+  }
 }

--- a/terraform/layers/20-security-pki/outputs.tf
+++ b/terraform/layers/20-security-pki/outputs.tf
@@ -8,6 +8,7 @@ output "pki_configuration" {
   description = "PKI Configuration Summary"
   value = {
     path             = module.vault_pki_setup.vault_pki_path
+    ca_cert          = module.vault_pki_setup.pki_root_ca_certificate
     dependency_roles = module.vault_pki_setup.dependency_roles
     component_roles  = module.vault_pki_setup.component_roles
   }

--- a/terraform/layers/30-infra-gitlab-kubeadm/output.tf
+++ b/terraform/layers/30-infra-gitlab-kubeadm/output.tf
@@ -1,7 +1,12 @@
 
 output "service_vip" {
-  description = "The virtual IP assigned to the Vault service from Central LB topology."
+  description = "The virtual IP assigned to the GitLab Kubeadm service from Central LB topology."
   value       = local.net_service_vip
+}
+
+output "pod_subnet" {
+  description = "The pod subnet CIDR used for the Kubernetes cluster."
+  value       = var.kubernetes_cluster_configuration.pod_subnet
 }
 
 output "credentials_system" {

--- a/terraform/layers/30-infra-gitlab-kubeadm/provider.tf
+++ b/terraform/layers/30-infra-gitlab-kubeadm/provider.tf
@@ -33,5 +33,5 @@ provider "vault" {
   alias        = "production"
   address      = local.sys_vault_addr
   token        = data.vault_generic_secret.prod_credential.data["prod_vault_root_token"]
-  ca_cert_file = local.state.vault_pki.bootstrap_ca_path
+  ca_cert_file = local.state.vault_pki.bootstrap_ca.path
 }

--- a/terraform/layers/30-infra-gitlab-minio/providers.tf
+++ b/terraform/layers/30-infra-gitlab-minio/providers.tf
@@ -33,7 +33,7 @@ provider "vault" {
   alias        = "production"
   address      = local.sys_vault_addr
   token        = data.vault_generic_secret.prod_credential.data["prod_vault_root_token"]
-  ca_cert_file = local.state.vault_pki.bootstrap_ca_path
+  ca_cert_file = local.state.vault_pki.bootstrap_ca.path
 }
 
 provider "minio" {

--- a/terraform/layers/30-infra-gitlab-postgres/providers.tf
+++ b/terraform/layers/30-infra-gitlab-postgres/providers.tf
@@ -33,5 +33,5 @@ provider "vault" {
   alias        = "production"
   address      = local.sys_vault_addr
   token        = data.vault_generic_secret.prod_credential.data["prod_vault_root_token"]
-  ca_cert_file = local.state.vault_pki.bootstrap_ca_path
+  ca_cert_file = local.state.vault_pki.bootstrap_ca.path
 }

--- a/terraform/layers/30-infra-gitlab-redis/providers.tf
+++ b/terraform/layers/30-infra-gitlab-redis/providers.tf
@@ -29,5 +29,5 @@ provider "vault" {
   alias        = "production"
   address      = local.sys_vault_addr
   token        = data.vault_generic_secret.prod_credential.data["prod_vault_root_token"]
-  ca_cert_file = data.terraform_remote_state.vault_pki.outputs.bootstrap_ca_path
+  ca_cert_file = data.terraform_remote_state.vault_pki.outputs.bootstrap_ca.path
 }

--- a/terraform/layers/30-infra-harbor-bootstrapper/providers.tf
+++ b/terraform/layers/30-infra-harbor-bootstrapper/providers.tf
@@ -29,5 +29,5 @@ provider "vault" {
   alias        = "production"
   address      = local.sys_vault_addr
   token        = data.vault_generic_secret.prod_credential.data["prod_vault_root_token"]
-  ca_cert_file = local.state.vault_pki.bootstrap_ca_path
+  ca_cert_file = local.state.vault_pki.bootstrap_ca.path
 }

--- a/terraform/layers/30-infra-harbor-microk8s/providers.tf
+++ b/terraform/layers/30-infra-harbor-microk8s/providers.tf
@@ -20,5 +20,5 @@ provider "vault" {
   alias        = "production"
   address      = local.sys_vault_addr
   token        = data.vault_generic_secret.prod_credential.data["prod_vault_root_token"]
-  ca_cert_file = local.state.vault_pki.bootstrap_ca_path
+  ca_cert_file = local.state.vault_pki.bootstrap_ca.path
 }

--- a/terraform/layers/30-infra-harbor-minio/providers.tf
+++ b/terraform/layers/30-infra-harbor-minio/providers.tf
@@ -32,7 +32,7 @@ provider "vault" {
   alias        = "production"
   address      = local.sys_vault_addr
   token        = data.vault_generic_secret.prod_credential.data["prod_vault_root_token"]
-  ca_cert_file = local.state.vault_pki.bootstrap_ca_path
+  ca_cert_file = local.state.vault_pki.bootstrap_ca.path
 }
 
 

--- a/terraform/layers/30-infra-harbor-postgres/providers.tf
+++ b/terraform/layers/30-infra-harbor-postgres/providers.tf
@@ -28,5 +28,5 @@ provider "vault" {
   alias        = "production"
   address      = local.sys_vault_addr
   token        = data.vault_generic_secret.prod_credential.data["prod_vault_root_token"]
-  ca_cert_file = local.state.vault_pki.bootstrap_ca_path
+  ca_cert_file = local.state.vault_pki.bootstrap_ca.path
 }

--- a/terraform/layers/30-infra-harbor-redis/providers.tf
+++ b/terraform/layers/30-infra-harbor-redis/providers.tf
@@ -29,5 +29,5 @@ provider "vault" {
   alias        = "production"
   address      = local.sys_vault_addr
   token        = data.vault_generic_secret.prod_credential.data["prod_vault_root_token"]
-  ca_cert_file = local.state.vault_pki.bootstrap_ca_path
+  ca_cert_file = local.state.vault_pki.bootstrap_ca.path
 }

--- a/terraform/layers/40-provision-harbor-bootstrapper/providers.tf
+++ b/terraform/layers/40-provision-harbor-bootstrapper/providers.tf
@@ -25,7 +25,7 @@ provider "vault" {
 provider "vault" {
   address      = local.sys_vault_addr
   token        = data.vault_generic_secret.prod_credential.data["prod_vault_root_token"]
-  ca_cert_file = local.state.vault_pki.bootstrap_ca_path
+  ca_cert_file = local.state.vault_pki.bootstrap_ca.path
 }
 
 provider "harbor" {

--- a/terraform/layers/50-platform-gitlab/.terraform.lock.hcl
+++ b/terraform/layers/50-platform-gitlab/.terraform.lock.hcl
@@ -60,18 +60,18 @@ provider "registry.opentofu.org/hashicorp/kubernetes" {
 }
 
 provider "registry.opentofu.org/hashicorp/vault" {
-  version     = "5.3.0"
-  constraints = "5.3.0"
+  version     = "5.5.0"
+  constraints = "5.5.0"
   hashes = [
-    "h1:MVP/hsKL/HtSK4X6JURW0RTrTgSqJdOLqNuTEwUgaqY=",
-    "zh:0443eae5c2fa688f794f6aa4eb01fc22cb8b903e0f86b846bc341f07885cf084",
-    "zh:1f08a5f4aebccce3cc8daa7ba32c89145f5af85c08bea4be1498c3f090aa1179",
-    "zh:2f9abd4f31964bd798daec2aca51a519934dce54585203122d550c8c960afcd1",
-    "zh:51aae772f54c332b6c40ba058e5fe31cec34f6f557b262c83d0bd613d11d58c1",
-    "zh:6c2331a804a6e3e0f30f707a4484a5817821c065f07a0b74e8225d267f1406e3",
-    "zh:a1c5bf3d72a0d8e688d4de26a3da7aadc5a827a1f469304436561ad5017adbdd",
-    "zh:b98e666b3124baa945c72b047ffd9a3b9e1765a95080f73735ef98cce244b889",
-    "zh:e0bcb3128d3b7af3e090f2e9c8a5727b1ac138b57835ed4d79a8fdddf74a7031",
-    "zh:f4d84985770ee54bb57611ece5186f3c83d3edec13c66d263d3efd474fe6e0e5",
+    "h1:Ci7enUOFKBmrcn3bQ9FqUMAMHw72c68uxuDiiK7dfHw=",
+    "zh:15ff2c9b424ba9f384fbda111316195d0f5a49078c23865392426161b37d33cd",
+    "zh:593544aca78d0913ea704e9091b5b99081d9b895450e9b7eb72cd121fe2c2ede",
+    "zh:7124e694e2440bb7eb01d9fb9cac907121ee29db39289d3374229d71cc670b62",
+    "zh:7ae0c25bb833af8e6d3c4d7a57a4f3171c1b91fca6ac46de760c91aec7d53a46",
+    "zh:84e155ce8bbf04be82744311640ea2c7225b3f9ced5321be26ab4e8e86aa4949",
+    "zh:baa9ea8dda1f720fd5901c842eddf11a0d3897b7a386cea0bff386b216db4033",
+    "zh:c62c7923effd59aa29298a401cdea6c1a7ac4c91782079a45b75be068243849b",
+    "zh:dffcb99c44e745c352cff7e338747e41734d6f5de3a2aa0f05b5df5cb00be3f9",
+    "zh:fe815a01c1dc279dd8de542efd77f953dc5bda99e0d673a2ce37a1cfab2c8121",
   ]
 }

--- a/terraform/layers/50-platform-gitlab/data.tf
+++ b/terraform/layers/50-platform-gitlab/data.tf
@@ -7,14 +7,6 @@ data "terraform_remote_state" "metadata" {
   }
 }
 
-# Kubeadm Cluster State
-data "terraform_remote_state" "kubeadm_provision" {
-  backend = "local"
-  config = {
-    path = "../30-infra-gitlab-kubeadm/terraform.tfstate"
-  }
-}
-
 # HashiCorp Vault State
 data "terraform_remote_state" "vault_pki" {
   backend = "local"
@@ -45,6 +37,14 @@ data "terraform_remote_state" "minio" {
   }
 }
 
+# Kubeadm Cluster State
+data "terraform_remote_state" "kubeadm" {
+  backend = "local"
+  config = {
+    path = "../30-infra-gitlab-kubeadm/terraform.tfstate"
+  }
+}
+
 # Harbor Bootstrapper State
 data "terraform_remote_state" "harbor_bootstrapper" {
   backend = "local"
@@ -62,7 +62,7 @@ data "vault_generic_secret" "prod_credential" {
 # 2. Fetch Kubeconfig from Production Vault
 data "vault_generic_secret" "kubeconfig" {
   provider = vault.production
-  path = "secret/on-premise-gitlab-deployment/infrastructure/kubeconfig/gitlab"
+  path     = "secret/on-premise-gitlab-deployment/infrastructure/kubeconfig/gitlab"
 }
 
 # Fetch the Cluster CA

--- a/terraform/layers/50-platform-gitlab/data.tf
+++ b/terraform/layers/50-platform-gitlab/data.tf
@@ -45,6 +45,14 @@ data "terraform_remote_state" "minio" {
   }
 }
 
+# Harbor Bootstrapper State
+data "terraform_remote_state" "harbor_bootstrapper" {
+  backend = "local"
+  config = {
+    path = "../40-provision-harbor-bootstrapper/terraform.tfstate"
+  }
+}
+
 # 1. Fetch Production Credential from Bootstrapper Vault
 data "vault_generic_secret" "prod_credential" {
   provider = vault.bootstrapper

--- a/terraform/layers/50-platform-gitlab/data.tf
+++ b/terraform/layers/50-platform-gitlab/data.tf
@@ -1,9 +1,17 @@
 
+# Foundation Metadata State (SSoT)
+data "terraform_remote_state" "metadata" {
+  backend = "local"
+  config = {
+    path = "../00-foundation-metadata/terraform.tfstate"
+  }
+}
+
 # Kubeadm Cluster State
 data "terraform_remote_state" "kubeadm_provision" {
   backend = "local"
   config = {
-    path = "../40-gitlab-kubeadm/terraform.tfstate"
+    path = "../30-infra-gitlab-kubeadm/terraform.tfstate"
   }
 }
 
@@ -11,7 +19,7 @@ data "terraform_remote_state" "kubeadm_provision" {
 data "terraform_remote_state" "vault_pki" {
   backend = "local"
   config = {
-    path = "../20-vault-pki/terraform.tfstate"
+    path = "../20-security-pki/terraform.tfstate"
   }
 }
 
@@ -19,27 +27,34 @@ data "terraform_remote_state" "vault_pki" {
 data "terraform_remote_state" "redis" {
   backend = "local"
   config = {
-    path = "../30-gitlab-redis/terraform.tfstate"
+    path = "../30-infra-gitlab-redis/terraform.tfstate"
   }
 }
 
 data "terraform_remote_state" "postgres" {
   backend = "local"
   config = {
-    path = "../30-gitlab-postgres/terraform.tfstate"
+    path = "../30-infra-gitlab-postgres/terraform.tfstate"
   }
 }
 
 data "terraform_remote_state" "minio" {
   backend = "local"
   config = {
-    path = "../30-gitlab-minio/terraform.tfstate"
+    path = "../30-infra-gitlab-minio/terraform.tfstate"
   }
 }
 
-# Vault Secrets for reading database and service passwords.
-data "vault_generic_secret" "db_vars" {
-  path = "secret/on-premise-gitlab-deployment/gitlab/databases"
+# 1. Fetch Production Credential from Bootstrapper Vault
+data "vault_generic_secret" "prod_credential" {
+  provider = vault.bootstrapper
+  path     = "secret/on-premise-gitlab-deployment/infrastructure"
+}
+
+# 2. Fetch Kubeconfig from Production Vault
+data "vault_generic_secret" "kubeconfig" {
+  provider = vault.production
+  path = "secret/on-premise-gitlab-deployment/infrastructure/kubeconfig/gitlab"
 }
 
 # Fetch the Cluster CA

--- a/terraform/layers/50-platform-gitlab/locals.tf
+++ b/terraform/layers/50-platform-gitlab/locals.tf
@@ -1,7 +1,7 @@
 
-# Provider Configuration (Restored)
+# 1. K8s Provider Authentication Context
 locals {
-  kubeconfig   = yamldecode(data.terraform_remote_state.kubeadm_provision.outputs.kubeconfig_content)
+  kubeconfig   = yamldecode(base64decode(data.vault_generic_secret.kubeconfig.data["content_b64"]))
   cluster_info = local.kubeconfig.clusters[0].cluster
   user_info    = local.kubeconfig.users[0].user
 
@@ -13,34 +13,42 @@ locals {
   }
 }
 
-# for platform-trust-engine module
+# 2. Addons & Trust Engine Context
 locals {
-  # K8s API Endpoint for Vault Callback
-  k8s_api_endpoint = "https://${data.terraform_remote_state.kubeadm_provision.outputs.gitlab_kubeadm_virtual_ip}:6443"
+  # SSoT Discovery
+  ssot_gitlab = data.terraform_remote_state.metadata.outputs.global_service_structure["gitlab"]
+  ssot_vault  = data.terraform_remote_state.metadata.outputs.global_service_structure["vault"]
+
+  # FQDNs
+  gitlab_fqdn = local.ssot_gitlab.components["frontend"].role.dns_san[0]
+  vault_fqdn  = local.ssot_vault.components["raft"].role.dns_san[0]
+
+  # K8s API Endpoint for Vault Callback (Standardized)
+  k8s_api_port     = local.ssot_gitlab.meta.ports["api-server"].frontend_port
+  k8s_api_endpoint = "https://${data.terraform_remote_state.kubeadm_provision.outputs.service_vip}:${local.k8s_api_port}"
 
   # Cluster CA from ConfigMap
   k8s_cluster_ca = data.kubernetes_config_map.kube_root_ca.data["ca.crt"]
 
-  # Vault Address
-  vault_address     = "https://${data.terraform_remote_state.vault_pki.outputs.vault_ha_virtual_ip}:443"
-  vault_policy_name = "${local.vault_role_name}-pki-policy"
-  vault_ca_cert     = data.terraform_remote_state.vault_pki.outputs.vault_certificates.ca_cert.ca_cert
+  # Vault Connection (Standardized)
+  vault_api_port    = local.ssot_vault.meta.ports["api"].frontend_port
+  vault_address     = "https://${data.terraform_remote_state.vault_pki.outputs.vault_service_vip}:${local.vault_api_port}"
+  vault_ca_cert     = data.terraform_remote_state.vault_pki.outputs.pki_configuration.ca_cert
   vault_pki_path    = data.terraform_remote_state.vault_pki.outputs.pki_configuration.path
   vault_role_name   = data.terraform_remote_state.vault_pki.outputs.pki_configuration.component_roles["gitlab-frontend"].name
   vault_auth_path   = data.terraform_remote_state.vault_pki.outputs.auth_backend_paths["kubernetes"]
-  # where `vault_auth_path` automatically fetch Auth Path (default is kubernetes, can be retrieved from map if changed).
+  vault_policy_name = "${local.vault_role_name}-pki-policy"
 }
 
-# DNS Configuration
+# 3. DNS Configuration (Standardized)
 locals {
   dns_hosts = {
-    # For Gitlab and Vault ingress VIP, respectively.
-    "${data.terraform_remote_state.kubeadm_provision.outputs.gitlab_kubeadm_virtual_ip}" = "gitlab.iac.local"
-    "${data.terraform_remote_state.vault_pki.outputs.vault_ha_virtual_ip}"               = "vault.iac.local"
+    "${data.terraform_remote_state.kubeadm_provision.outputs.service_vip}" = local.gitlab_fqdn
+    "${data.terraform_remote_state.vault_pki.outputs.vault_service_vip}"   = local.vault_fqdn
 
-    # For dependency roles.
-    "${data.terraform_remote_state.redis.outputs.gitlab_redis_virtual_ip}"       = data.terraform_remote_state.vault_pki.outputs.pki_configuration.dependency_roles["gitlab-redis"].allowed_domains[0]
-    "${data.terraform_remote_state.postgres.outputs.gitlab_postgres_virtual_ip}" = data.terraform_remote_state.vault_pki.outputs.pki_configuration.dependency_roles["gitlab-postgres"].allowed_domains[0]
-    "${data.terraform_remote_state.minio.outputs.gitlab_minio_virtual_ip}"       = data.terraform_remote_state.vault_pki.outputs.pki_configuration.dependency_roles["gitlab-minio"].allowed_domains[0]
+    # Dependency Roles
+    "${data.terraform_remote_state.redis.outputs.service_vip}"    = data.terraform_remote_state.vault_pki.outputs.pki_configuration.dependency_roles["gitlab-redis-dep"].allowed_domains[0]
+    "${data.terraform_remote_state.postgres.outputs.service_vip}" = data.terraform_remote_state.vault_pki.outputs.pki_configuration.dependency_roles["gitlab-postgres-dep"].allowed_domains[0]
+    "${data.terraform_remote_state.minio.outputs.service_vip}"    = data.terraform_remote_state.vault_pki.outputs.pki_configuration.dependency_roles["gitlab-minio-dep"].allowed_domains[0]
   }
 }

--- a/terraform/layers/50-platform-gitlab/locals.tf
+++ b/terraform/layers/50-platform-gitlab/locals.tf
@@ -23,6 +23,10 @@ locals {
   gitlab_fqdn = local.ssot_gitlab.components["frontend"].role.dns_san[0]
   vault_fqdn  = local.ssot_vault.components["raft"].role.dns_san[0]
 
+  # Harbor Bootstrapper (Registry Redirection)
+  harbor_registry   = data.terraform_remote_state.metadata.outputs.global_service_structure["harbor-bootstrapper"].components.frontend.role.dns_san[0]
+  harbor_image_path = "quay-proxy"
+
   # K8s API Endpoint for Vault Callback (Standardized)
   k8s_api_port     = local.ssot_gitlab.meta.ports["api-server"].frontend_port
   k8s_api_endpoint = "https://${data.terraform_remote_state.kubeadm_provision.outputs.service_vip}:${local.k8s_api_port}"

--- a/terraform/layers/50-platform-gitlab/locals.tf
+++ b/terraform/layers/50-platform-gitlab/locals.tf
@@ -33,7 +33,7 @@ locals {
   # Vault Connection (Standardized)
   vault_api_port    = local.ssot_vault.meta.ports["api"].frontend_port
   vault_address     = "https://${data.terraform_remote_state.vault_pki.outputs.vault_service_vip}:${local.vault_api_port}"
-  vault_ca_cert     = data.terraform_remote_state.vault_pki.outputs.pki_configuration.ca_cert
+  vault_ca_cert     = data.terraform_remote_state.vault_pki.outputs.bootstrap_ca.content
   vault_pki_path    = data.terraform_remote_state.vault_pki.outputs.pki_configuration.path
   vault_role_name   = data.terraform_remote_state.vault_pki.outputs.pki_configuration.component_roles["gitlab-frontend"].name
   vault_auth_path   = data.terraform_remote_state.vault_pki.outputs.auth_backend_paths["kubernetes"]

--- a/terraform/layers/50-platform-gitlab/locals.tf
+++ b/terraform/layers/50-platform-gitlab/locals.tf
@@ -5,11 +5,11 @@ locals {
   cluster_info = local.kubeconfig.clusters[0].cluster
   user_info    = local.kubeconfig.users[0].user
 
-  k8s_provider_auth = {
-    host                   = local.cluster_info.server
-    cluster_ca_certificate = base64decode(local.cluster_info["certificate-authority-data"])
-    client_certificate     = base64decode(local.user_info["client-certificate-data"])
-    client_key             = base64decode(local.user_info["client-key-data"])
+  api_server_connection = {
+    host               = local.cluster_info.server
+    ca_cert            = base64decode(local.cluster_info["certificate-authority-data"])
+    client_certificate = base64decode(local.user_info["client-certificate-data"])
+    client_key         = base64decode(local.user_info["client-key-data"])
   }
 }
 
@@ -28,11 +28,11 @@ locals {
   harbor_image_path = "quay-proxy"
 
   # K8s API Endpoint for Vault Callback (Standardized)
-  k8s_api_port     = local.ssot_gitlab.meta.ports["api-server"].frontend_port
-  k8s_api_endpoint = "https://${data.terraform_remote_state.kubeadm_provision.outputs.service_vip}:${local.k8s_api_port}"
+  api_port     = local.ssot_gitlab.meta.ports["api-server"].frontend_port
+  api_endpoint = "https://${data.terraform_remote_state.kubeadm_provision.outputs.service_vip}:${local.api_port}"
 
   # Cluster CA from ConfigMap
-  k8s_cluster_ca = data.kubernetes_config_map.kube_root_ca.data["ca.crt"]
+  cluster_ca = data.kubernetes_config_map.kube_root_ca.data["ca.crt"]
 
   # Vault Connection (Standardized)
   vault_api_port    = local.ssot_vault.meta.ports["api"].frontend_port

--- a/terraform/layers/50-platform-gitlab/locals.tf
+++ b/terraform/layers/50-platform-gitlab/locals.tf
@@ -1,5 +1,17 @@
+# 1. External State Context
+locals {
+  state = {
+    metadata            = data.terraform_remote_state.metadata.outputs
+    vault_pki           = data.terraform_remote_state.vault_pki.outputs
+    redis               = data.terraform_remote_state.redis.outputs
+    postgres            = data.terraform_remote_state.postgres.outputs
+    minio               = data.terraform_remote_state.minio.outputs
+    kubeadm             = data.terraform_remote_state.kubeadm.outputs
+    harbor_bootstrapper = data.terraform_remote_state.harbor_bootstrapper.outputs
+  }
+}
 
-# 1. K8s Provider Authentication Context
+# 2. K8s Provider Authentication Context
 locals {
   kubeconfig   = yamldecode(base64decode(data.vault_generic_secret.kubeconfig.data["content_b64"]))
   cluster_info = local.kubeconfig.clusters[0].cluster
@@ -13,48 +25,48 @@ locals {
   }
 }
 
-# 2. Addons & Trust Engine Context
+# 3. Addons & Trust Engine Context
 locals {
   # SSoT Discovery
-  ssot_gitlab = data.terraform_remote_state.metadata.outputs.global_service_structure["gitlab"]
-  ssot_vault  = data.terraform_remote_state.metadata.outputs.global_service_structure["vault"]
+  ssot_gitlab = local.state.metadata.global_service_structure["gitlab"]
+  ssot_vault  = local.state.metadata.global_service_structure["vault"]
 
   # FQDNs
   gitlab_fqdn = local.ssot_gitlab.components["frontend"].role.dns_san[0]
   vault_fqdn  = local.ssot_vault.components["raft"].role.dns_san[0]
 
   # Harbor Bootstrapper (Registry Redirection)
-  harbor_registry     = data.terraform_remote_state.metadata.outputs.global_service_structure["harbor-bootstrapper"].components.frontend.role.dns_san[0]
-  harbor_quay_proxy   = data.terraform_remote_state.harbor_bootstrapper.outputs.proxy_caches.quay_io.project_name
-  harbor_k8s_proxy    = data.terraform_remote_state.harbor_bootstrapper.outputs.proxy_caches.k8s_io.project_name
-  harbor_docker_proxy = data.terraform_remote_state.harbor_bootstrapper.outputs.proxy_caches.docker_hub.project_name
+  harbor_registry     = local.state.metadata.global_service_structure["harbor-bootstrapper"].components.frontend.role.dns_san[0]
+  harbor_quay_proxy   = local.state.harbor_bootstrapper.proxy_caches.quay_io.project_name
+  harbor_k8s_proxy    = local.state.harbor_bootstrapper.proxy_caches.k8s_io.project_name
+  harbor_docker_proxy = local.state.harbor_bootstrapper.proxy_caches.docker_hub.project_name
 
   # K8s API Endpoint for Vault Callback (Standardized)
   api_port     = local.ssot_gitlab.meta.ports["api-server"].frontend_port
-  api_endpoint = "https://${data.terraform_remote_state.kubeadm_provision.outputs.service_vip}:${local.api_port}"
+  api_endpoint = "https://${local.state.kubeadm.service_vip}:${local.api_port}"
 
   # Cluster CA from ConfigMap
   cluster_ca = data.kubernetes_config_map.kube_root_ca.data["ca.crt"]
 
   # Vault Connection (Standardized)
   vault_api_port    = local.ssot_vault.meta.ports["api"].frontend_port
-  vault_address     = "https://${data.terraform_remote_state.vault_pki.outputs.vault_service_vip}:${local.vault_api_port}"
-  vault_ca_cert     = data.terraform_remote_state.vault_pki.outputs.bootstrap_ca.content
-  vault_pki_path    = data.terraform_remote_state.vault_pki.outputs.pki_configuration.path
-  vault_role_name   = data.terraform_remote_state.vault_pki.outputs.pki_configuration.component_roles["gitlab-frontend"].name
-  vault_auth_path   = data.terraform_remote_state.vault_pki.outputs.auth_backend_paths["kubernetes"]
+  vault_address     = "https://${local.state.vault_pki.vault_service_vip}:${local.vault_api_port}"
+  vault_ca_cert     = local.state.vault_pki.bootstrap_ca.content
+  vault_pki_path    = local.state.vault_pki.pki_configuration.path
+  vault_role_name   = local.state.vault_pki.pki_configuration.component_roles["gitlab-frontend"].name
+  vault_auth_path   = local.state.vault_pki.auth_backend_paths["kubernetes"]
   vault_policy_name = "${local.vault_role_name}-pki-policy"
 }
 
-# 3. DNS Configuration (Standardized)
+# 4. DNS Configuration (Standardized)
 locals {
   dns_hosts = {
-    "${data.terraform_remote_state.kubeadm_provision.outputs.service_vip}" = local.gitlab_fqdn
-    "${data.terraform_remote_state.vault_pki.outputs.vault_service_vip}"   = local.vault_fqdn
+    "${local.state.kubeadm.service_vip}"   = local.gitlab_fqdn
+    "${local.state.vault_pki.vault_service_vip}" = local.vault_fqdn
 
     # Dependency Roles
-    "${data.terraform_remote_state.redis.outputs.service_vip}"    = data.terraform_remote_state.vault_pki.outputs.pki_configuration.dependency_roles["gitlab-redis-dep"].allowed_domains[0]
-    "${data.terraform_remote_state.postgres.outputs.service_vip}" = data.terraform_remote_state.vault_pki.outputs.pki_configuration.dependency_roles["gitlab-postgres-dep"].allowed_domains[0]
-    "${data.terraform_remote_state.minio.outputs.service_vip}"    = data.terraform_remote_state.vault_pki.outputs.pki_configuration.dependency_roles["gitlab-minio-dep"].allowed_domains[0]
+    "${local.state.redis.service_vip}"    = local.state.vault_pki.pki_configuration.dependency_roles["gitlab-redis-dep"].allowed_domains[0]
+    "${local.state.postgres.service_vip}" = local.state.vault_pki.pki_configuration.dependency_roles["gitlab-postgres-dep"].allowed_domains[0]
+    "${local.state.minio.service_vip}"    = local.state.vault_pki.pki_configuration.dependency_roles["gitlab-minio-dep"].allowed_domains[0]
   }
 }

--- a/terraform/layers/50-platform-gitlab/locals.tf
+++ b/terraform/layers/50-platform-gitlab/locals.tf
@@ -24,8 +24,10 @@ locals {
   vault_fqdn  = local.ssot_vault.components["raft"].role.dns_san[0]
 
   # Harbor Bootstrapper (Registry Redirection)
-  harbor_registry   = data.terraform_remote_state.metadata.outputs.global_service_structure["harbor-bootstrapper"].components.frontend.role.dns_san[0]
-  harbor_image_path = "quay-proxy"
+  harbor_registry     = data.terraform_remote_state.metadata.outputs.global_service_structure["harbor-bootstrapper"].components.frontend.role.dns_san[0]
+  harbor_quay_proxy   = data.terraform_remote_state.harbor_bootstrapper.outputs.proxy_caches.quay_io.project_name
+  harbor_k8s_proxy    = data.terraform_remote_state.harbor_bootstrapper.outputs.proxy_caches.k8s_io.project_name
+  harbor_docker_proxy = data.terraform_remote_state.harbor_bootstrapper.outputs.proxy_caches.docker_hub.project_name
 
   # K8s API Endpoint for Vault Callback (Standardized)
   api_port     = local.ssot_gitlab.meta.ports["api-server"].frontend_port

--- a/terraform/layers/50-platform-gitlab/main.tf
+++ b/terraform/layers/50-platform-gitlab/main.tf
@@ -1,7 +1,7 @@
 
 module "tigera_calico" {
   source         = "../../modules/kubernetes-addons/tigera-calico"
-  pod_subnet     = data.terraform_remote_state.kubeadm_provision.outputs.pod_subnet
+  pod_subnet     = local.state.kubeadm.pod_subnet
   image_registry = local.harbor_registry
   image_path     = local.harbor_quay_proxy
 }

--- a/terraform/layers/50-platform-gitlab/main.tf
+++ b/terraform/layers/50-platform-gitlab/main.tf
@@ -1,14 +1,15 @@
 
 module "k8s_calico" {
   source     = "../../modules/kubernetes-addons/tigera-calico"
-  pod_subnet = data.terraform_remote_state.kubeadm_provision.outputs.gitlab_pod_subnet
+  pod_subnet = data.terraform_remote_state.kubeadm_provision.outputs.pod_subnet
 }
 
 # [REFACTORED] Trust Engine Integration
-# Replaces the previous "k8s_cert_manager" module.
-# This standardizes the identity bootstrapping across Harbor (MicroK8s) and GitLab (Kubeadm).
 module "platform_trust_engine" {
   source = "../../modules/kubernetes-addons/platform-trust-engine"
+  providers = {
+    vault = vault.production
+  }
 
   # 1. K8s Cluster Connection (for Vault to call back)
   k8s_connection = {
@@ -25,12 +26,12 @@ module "platform_trust_engine" {
 
   # 3. Issuer Configuration (The "Contract" between K8s and Vault)
   issuer_config = {
-    name             = var.trust_engine_config.issuer_name           # e.g., "vault-issuer"
-    issue_path       = "sign"                                        # Matches Vault PKI path convention
-    vault_role_name  = local.vault_role_name                         # e.g., "gitlab-frontend-role"
-    pki_mount_path   = local.vault_pki_path                          # e.g., "pki/prod"
-    bound_namespaces = var.trust_engine_config.authorized_namespaces # e.g., ["gitlab", "cert-manager"]
-    token_policies   = [local.vault_policy_name]                     # e.g., ["gitlab-frontend-role-pki-policy"]
+    name             = var.trust_engine_config.issuer_name
+    issue_path       = "sign"
+    vault_role_name  = local.vault_role_name
+    pki_mount_path   = local.vault_pki_path
+    bound_namespaces = var.trust_engine_config.authorized_namespaces
+    token_policies   = [local.vault_policy_name]
   }
 
   # 4. Reviewer Identity (The entity that validates tokens)
@@ -50,7 +51,7 @@ module "platform_trust_engine" {
   # Ensure CNI is ready before installing Cert-Manager
   depends_on = [module.k8s_calico]
 }
-
+/*
 module "k8s_metric_server" {
   source     = "../../modules/kubernetes-addons/metric-server"
   depends_on = [module.platform_trust_engine]
@@ -73,3 +74,4 @@ module "coredns_config" {
 
   hosts = local.dns_hosts
 }
+*/

--- a/terraform/layers/50-platform-gitlab/main.tf
+++ b/terraform/layers/50-platform-gitlab/main.tf
@@ -1,7 +1,9 @@
 
 module "k8s_calico" {
-  source     = "../../modules/kubernetes-addons/tigera-calico"
-  pod_subnet = data.terraform_remote_state.kubeadm_provision.outputs.pod_subnet
+  source         = "../../modules/kubernetes-addons/tigera-calico"
+  pod_subnet     = data.terraform_remote_state.kubeadm_provision.outputs.pod_subnet
+  image_registry = local.harbor_registry
+  image_path     = local.harbor_image_path
 }
 
 # [REFACTORED] Trust Engine Integration

--- a/terraform/layers/50-platform-gitlab/main.tf
+++ b/terraform/layers/50-platform-gitlab/main.tf
@@ -1,5 +1,5 @@
 
-module "k8s_calico" {
+module "tigera_calico" {
   source         = "../../modules/kubernetes-addons/tigera-calico"
   pod_subnet     = data.terraform_remote_state.kubeadm_provision.outputs.pod_subnet
   image_registry = local.harbor_registry
@@ -14,9 +14,9 @@ module "platform_trust_engine" {
   }
 
   # 1. K8s Cluster Connection (for Vault to call back)
-  k8s_connection = {
-    host    = local.k8s_api_endpoint
-    ca_cert = local.k8s_cluster_ca
+  api_server_connection = {
+    host    = local.api_endpoint
+    ca_cert = local.cluster_ca
   }
 
   # 2. Vault Connection (for Cert-Manager to authenticate)
@@ -48,31 +48,33 @@ module "platform_trust_engine" {
     version          = var.cert_manager_config.version
     namespace        = var.cert_manager_config.namespace
     create_namespace = true
+    image_registry   = local.harbor_registry
+    image_repository = "${local.harbor_image_path}/jetstack"
   }
 
   # Ensure CNI is ready before installing Cert-Manager
-  depends_on = [module.k8s_calico]
+  depends_on = [module.tigera_calico]
 }
 /*
-module "k8s_metric_server" {
+module "metric_server" {
   source     = "../../modules/kubernetes-addons/metric-server"
   depends_on = [module.platform_trust_engine]
 }
 
-module "k8s_ingress_nginx" {
+module "ingress_nginx" {
   source     = "../../modules/kubernetes-addons/ingress-nginx"
   depends_on = [module.platform_trust_engine]
 }
 
-module "k8s_storage_local_path" {
+module "storage_local_path" {
   source     = "../../modules/kubernetes-addons/local-path-provisioner"
-  depends_on = [module.k8s_calico]
+  depends_on = [module.tigera_calico]
 }
 
 # CoreDNS Configuration
 module "coredns_config" {
   source     = "../../modules/kubernetes-addons/coredns-config"
-  depends_on = [module.k8s_calico]
+  depends_on = [module.tigera_calico]
 
   hosts = local.dns_hosts
 }

--- a/terraform/layers/50-platform-gitlab/main.tf
+++ b/terraform/layers/50-platform-gitlab/main.tf
@@ -3,7 +3,7 @@ module "tigera_calico" {
   source         = "../../modules/kubernetes-addons/tigera-calico"
   pod_subnet     = data.terraform_remote_state.kubeadm_provision.outputs.pod_subnet
   image_registry = local.harbor_registry
-  image_path     = local.harbor_image_path
+  image_path     = local.harbor_quay_proxy
 }
 
 # [REFACTORED] Trust Engine Integration
@@ -49,25 +49,50 @@ module "platform_trust_engine" {
     namespace        = var.cert_manager_config.namespace
     create_namespace = true
     image_registry   = local.harbor_registry
-    image_repository = "${local.harbor_image_path}/jetstack"
+    image_repository = "${local.harbor_quay_proxy}/jetstack"
   }
 
   # Ensure CNI is ready before installing Cert-Manager
   depends_on = [module.tigera_calico]
 }
-/*
+
 module "metric_server" {
-  source     = "../../modules/kubernetes-addons/metric-server"
+  source = "../../modules/kubernetes-addons/metric-server"
+  helm_config = {
+    install          = true
+    version          = var.metric_server_config.version
+    namespace        = var.metric_server_config.namespace
+    create_namespace = true
+    image_registry   = local.harbor_registry
+    image_repository = "${local.harbor_k8s_proxy}/metrics-server"
+  }
   depends_on = [module.platform_trust_engine]
 }
 
 module "ingress_nginx" {
-  source     = "../../modules/kubernetes-addons/ingress-nginx"
+  source = "../../modules/kubernetes-addons/ingress-nginx"
+  helm_config = {
+    install          = true
+    version          = var.ingress_nginx_config.version
+    namespace        = var.ingress_nginx_config.namespace
+    create_namespace = true
+    image_registry   = local.harbor_registry
+    image_repository = "${local.harbor_k8s_proxy}/ingress-nginx"
+  }
   depends_on = [module.platform_trust_engine]
 }
 
 module "storage_local_path" {
-  source     = "../../modules/kubernetes-addons/local-path-provisioner"
+  source = "../../modules/kubernetes-addons/local-path-provisioner"
+  helm_config = {
+    install                 = true
+    version                 = var.local_path_config.version
+    namespace               = var.local_path_config.namespace
+    create_namespace        = true
+    image_registry          = local.harbor_registry
+    image_repository        = "${local.harbor_docker_proxy}/rancher"
+    helper_image_repository = "${local.harbor_docker_proxy}/library"
+  }
   depends_on = [module.tigera_calico]
 }
 
@@ -78,4 +103,3 @@ module "coredns_config" {
 
   hosts = local.dns_hosts
 }
-*/

--- a/terraform/layers/50-platform-gitlab/output.tf
+++ b/terraform/layers/50-platform-gitlab/output.tf
@@ -8,11 +8,18 @@ output "trust_context" {
 }
 
 output "ingress_context" {
-  description = "Ingress controller details"
+  description = "Ingress controller details formatted for SSoT consumption"
   value = {
-    class_name       = var.ingress_class_name
-    load_balancer_ip = data.terraform_remote_state.kubeadm_provision.outputs.gitlab_kubeadm_virtual_ip
-    http_node_ports  = data.terraform_remote_state.kubeadm_provision.outputs.gitlab_http_nodeport
-    https_node_ports = data.terraform_remote_state.kubeadm_provision.outputs.gitlab_https_nodeport
+    load_balancer_ip = data.terraform_remote_state.kubeadm_provision.outputs.service_vip
+    http_node_port   = local.ssot_gitlab.meta.ports["ingress-http"].backend_port
+    https_node_port  = local.ssot_gitlab.meta.ports["ingress-https"].backend_port
+  }
+}
+
+output "cert_manager_info" {
+  description = "Summary of Cert-Manager and Issuer installation"
+  value = {
+    namespace   = var.cert_manager_config.namespace
+    issuer_name = var.trust_engine_config.issuer_name
   }
 }

--- a/terraform/layers/50-platform-gitlab/output.tf
+++ b/terraform/layers/50-platform-gitlab/output.tf
@@ -20,6 +20,6 @@ output "cert_manager_info" {
   description = "Summary of Cert-Manager and Issuer installation"
   value = {
     namespace   = var.cert_manager_config.namespace
-    issuer_name = var.trust_engine_config.issuer_name
+    issuer_name = module.platform_trust_engine.issuer_name
   }
 }

--- a/terraform/layers/50-platform-gitlab/output.tf
+++ b/terraform/layers/50-platform-gitlab/output.tf
@@ -10,7 +10,7 @@ output "trust_context" {
 output "ingress_context" {
   description = "Ingress controller details formatted for SSoT consumption"
   value = {
-    load_balancer_ip = data.terraform_remote_state.kubeadm_provision.outputs.service_vip
+    load_balancer_ip = local.state.kubeadm.service_vip
     http_node_port   = local.ssot_gitlab.meta.ports["ingress-http"].backend_port
     https_node_port  = local.ssot_gitlab.meta.ports["ingress-https"].backend_port
   }

--- a/terraform/layers/50-platform-gitlab/providers.tf
+++ b/terraform/layers/50-platform-gitlab/providers.tf
@@ -15,15 +15,23 @@ terraform {
     }
     vault = {
       source  = "hashicorp/vault"
-      version = "5.3.0"
+      version = "5.5.0"
     }
   }
 }
 
 provider "vault" {
+  alias        = "bootstrapper"
+  address      = var.vault_dev_addr
+  token        = trimspace(file(abspath("${path.root}/../../../vault/keys/root-token.txt")))
+  ca_cert_file = abspath("${path.root}/../../../vault/tls/ca.pem")
+}
+
+provider "vault" {
+  alias        = "production"
   address      = local.vault_address
-  ca_cert_file = abspath("${path.root}/../10-vault-raft/tls/vault-ca.crt")
-  token        = jsondecode(file(abspath("${path.root}/../../../ansible/fetched/vault/vault_init_output.json"))).root_token
+  ca_cert_file = data.terraform_remote_state.vault_pki.outputs.bootstrap_ca_path
+  token        = data.vault_generic_secret.prod_credential.data["prod_vault_root_token"]
 }
 
 # Configure the Kubernetes provider using details from the remote state

--- a/terraform/layers/50-platform-gitlab/providers.tf
+++ b/terraform/layers/50-platform-gitlab/providers.tf
@@ -36,25 +36,25 @@ provider "vault" {
 
 # Configure the Kubernetes provider using details from the remote state
 provider "kubernetes" {
-  host                   = local.k8s_provider_auth.host
-  cluster_ca_certificate = local.k8s_provider_auth.cluster_ca_certificate
-  client_certificate     = local.k8s_provider_auth.client_certificate
-  client_key             = local.k8s_provider_auth.client_key
+  host                   = local.api_server_connection.host
+  cluster_ca_certificate = local.api_server_connection.ca_cert
+  client_certificate     = local.api_server_connection.client_certificate
+  client_key             = local.api_server_connection.client_key
 }
 
 provider "kubectl" {
   load_config_file       = false
-  host                   = local.k8s_provider_auth.host
-  cluster_ca_certificate = local.k8s_provider_auth.cluster_ca_certificate
-  client_certificate     = local.k8s_provider_auth.client_certificate
-  client_key             = local.k8s_provider_auth.client_key
+  host                   = local.api_server_connection.host
+  cluster_ca_certificate = local.api_server_connection.ca_cert
+  client_certificate     = local.api_server_connection.client_certificate
+  client_key             = local.api_server_connection.client_key
 }
 
 provider "helm" {
   kubernetes = {
-    host                   = local.k8s_provider_auth.host
-    cluster_ca_certificate = local.k8s_provider_auth.cluster_ca_certificate
-    client_certificate     = local.k8s_provider_auth.client_certificate
-    client_key             = local.k8s_provider_auth.client_key
+    host                   = local.api_server_connection.host
+    cluster_ca_certificate = local.api_server_connection.ca_cert
+    client_certificate     = local.api_server_connection.client_certificate
+    client_key             = local.api_server_connection.client_key
   }
 }

--- a/terraform/layers/50-platform-gitlab/providers.tf
+++ b/terraform/layers/50-platform-gitlab/providers.tf
@@ -30,7 +30,7 @@ provider "vault" {
 provider "vault" {
   alias        = "production"
   address      = local.vault_address
-  ca_cert_file = data.terraform_remote_state.vault_pki.outputs.bootstrap_ca_path
+  ca_cert_file = data.terraform_remote_state.vault_pki.outputs.bootstrap_ca.path
   token        = data.vault_generic_secret.prod_credential.data["prod_vault_root_token"]
 }
 

--- a/terraform/layers/50-platform-gitlab/variables.tf
+++ b/terraform/layers/50-platform-gitlab/variables.tf
@@ -6,6 +6,11 @@ variable "trust_engine_config" {
     issuer_kind           = string       # e.g., "ClusterIssuer"
     authorized_namespaces = list(string) # e.g., ["cert-manager", "gitlab"]
   })
+  default = {
+    issuer_name           = "vault-issuer"
+    issuer_kind           = "ClusterIssuer"
+    authorized_namespaces = ["cert-manager", "gitlab"]
+  }
 }
 
 variable "cert_manager_config" {
@@ -14,10 +19,14 @@ variable "cert_manager_config" {
     version   = string # e.g., "v1.14.0"
     namespace = string # e.g., "cert-manager"
   })
+  default = {
+    version   = "v1.14.0"
+    namespace = "cert-manager"
+  }
 }
 
-variable "ingress_class_name" {
-  description = "Ingress class name"
+variable "vault_dev_addr" {
+  description = "The address of the Bootstrapper Vault (Podman Vault)"
   type        = string
-  default     = "nginx"
+  default     = "https://127.0.0.1:8200"
 }

--- a/terraform/layers/50-platform-gitlab/variables.tf
+++ b/terraform/layers/50-platform-gitlab/variables.tf
@@ -30,3 +30,39 @@ variable "vault_dev_addr" {
   type        = string
   default     = "https://127.0.0.1:8200"
 }
+
+variable "metric_server_config" {
+  description = "Configuration for Metrics Server"
+  type = object({
+    version   = string
+    namespace = string
+  })
+  default = {
+    version   = "3.13.0"
+    namespace = "kube-system"
+  }
+}
+
+variable "ingress_nginx_config" {
+  description = "Configuration for Ingress Nginx"
+  type = object({
+    version   = string
+    namespace = string
+  })
+  default = {
+    version   = "4.13.1"
+    namespace = "ingress-nginx"
+  }
+}
+
+variable "local_path_config" {
+  description = "Configuration for Local Path Provisioner"
+  type = object({
+    version   = string
+    namespace = string
+  })
+  default = {
+    version   = "0.0.35"
+    namespace = "kube-system"
+  }
+}

--- a/terraform/modules/kubernetes-addons/ingress-nginx/main.tf
+++ b/terraform/modules/kubernetes-addons/ingress-nginx/main.tf
@@ -1,18 +1,33 @@
 
 resource "helm_release" "ingress_nginx" {
-
-  # Ref: https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx
-  #
-  # Note that the NodePort should be same in the HAProxy configuration 
-  # File: 'ansible/roles/35-kubeadm-ha-haproxy/templates/haproxy.cfg.j2'
+  count = var.helm_config.install ? 1 : 0
 
   name             = "ingress-nginx"
   repository       = "https://kubernetes.github.io/ingress-nginx"
   chart            = "ingress-nginx"
-  namespace        = "ingress-nginx"
-  create_namespace = true
-  version          = "4.13.1"
+  namespace        = var.helm_config.namespace
+  create_namespace = var.helm_config.create_namespace
+  version          = var.helm_config.version
   cleanup_on_fail  = true
+
+  set = [
+    {
+      name  = "controller.image.registry"
+      value = var.helm_config.image_registry
+    },
+    {
+      name  = "controller.image.image"
+      value = "${var.helm_config.image_repository}/controller"
+    },
+    {
+      name  = "controller.admissionWebhooks.patch.image.registry"
+      value = var.helm_config.image_registry
+    },
+    {
+      name  = "controller.admissionWebhooks.patch.image.image"
+      value = "${var.helm_config.image_repository}/kube-webhook-certgen"
+    }
+  ]
 
   values = [
     yamlencode({
@@ -56,11 +71,12 @@ resource "helm_release" "ingress_nginx" {
 
 # Search for Ingress NGINX Controller Service created by Helm Chart
 data "kubernetes_service_v1" "ingress_nginx_controller" {
+  count = var.helm_config.install ? 1 : 0
 
   depends_on = [helm_release.ingress_nginx]
 
   metadata {
-    name      = "${helm_release.ingress_nginx.name}-controller"
-    namespace = helm_release.ingress_nginx.namespace
+    name      = "${helm_release.ingress_nginx[0].name}-controller"
+    namespace = helm_release.ingress_nginx[0].namespace
   }
 }

--- a/terraform/modules/kubernetes-addons/ingress-nginx/output.tf
+++ b/terraform/modules/kubernetes-addons/ingress-nginx/output.tf
@@ -1,6 +1,7 @@
+
 output "service_node_ports" {
   description = "NodePort mappings for the Ingress NGINX controller service."
-  value = {
-    for port in data.kubernetes_service_v1.ingress_nginx_controller.spec[0].port : port.name => port.node_port
-  }
+  value = (var.helm_config.install && length(data.kubernetes_service_v1.ingress_nginx_controller) > 0) ? {
+    for port in data.kubernetes_service_v1.ingress_nginx_controller[0].spec[0].port : port.name => port.node_port
+  } : {}
 }

--- a/terraform/modules/kubernetes-addons/ingress-nginx/variables.tf
+++ b/terraform/modules/kubernetes-addons/ingress-nginx/variables.tf
@@ -1,0 +1,20 @@
+
+variable "helm_config" {
+  description = "Ingress Nginx Helm Chart installation configuration"
+  type = object({
+    install          = bool
+    version          = string
+    namespace        = string
+    create_namespace = bool
+    image_registry   = string
+    image_repository = string
+  })
+  default = {
+    install          = true
+    version          = "4.13.1"
+    namespace        = "ingress-nginx"
+    create_namespace = true
+    image_registry   = "registry.k8s.io"
+    image_repository = "ingress-nginx"
+  }
+}

--- a/terraform/modules/kubernetes-addons/local-path-provisioner/main.tf
+++ b/terraform/modules/kubernetes-addons/local-path-provisioner/main.tf
@@ -1,10 +1,13 @@
 
 resource "helm_release" "local_path_provisioner" {
-  name       = "local-path-storage"
-  repository = "https://charts.containeroo.ch"
-  chart      = "local-path-provisioner"
-  version    = "0.0.35"
-  namespace  = "kube-system"
+  count = var.helm_config.install ? 1 : 0
+
+  name             = "local-path-storage"
+  repository       = "https://charts.containeroo.ch"
+  chart            = "local-path-provisioner"
+  version          = var.helm_config.version
+  namespace        = var.helm_config.namespace
+  create_namespace = var.helm_config.create_namespace
 
   set = [
     {
@@ -18,6 +21,14 @@ resource "helm_release" "local_path_provisioner" {
     {
       name  = "nodePath"
       value = "/opt/local-path-provisioner"
+    },
+    {
+      name  = "image.repository"
+      value = "${var.helm_config.image_registry}/${var.helm_config.image_repository}/local-path-provisioner"
+    },
+    {
+      name  = "helperImage.repository"
+      value = "${var.helm_config.image_registry}/${var.helm_config.helper_image_repository}/busybox"
     }
   ]
 }

--- a/terraform/modules/kubernetes-addons/local-path-provisioner/variables.tf
+++ b/terraform/modules/kubernetes-addons/local-path-provisioner/variables.tf
@@ -1,0 +1,22 @@
+
+variable "helm_config" {
+  description = "Local Path Provisioner Helm Chart installation configuration"
+  type = object({
+    install          = bool
+    version          = string
+    namespace        = string
+    create_namespace = bool
+    image_registry          = string
+    image_repository        = string
+    helper_image_repository = string
+  })
+  default = {
+    install                 = true
+    version                 = "0.0.35"
+    namespace               = "kube-system"
+    create_namespace        = true
+    image_registry          = "docker.io"
+    image_repository        = "rancher"
+    helper_image_repository = "library"
+  }
+}

--- a/terraform/modules/kubernetes-addons/metric-server/main.tf
+++ b/terraform/modules/kubernetes-addons/metric-server/main.tf
@@ -1,20 +1,23 @@
 
 resource "helm_release" "metrics_server" {
+  count = var.helm_config.install ? 1 : 0
 
-  # Ref: https://artifacthub.io/packages/helm/metrics-server/metrics-server
+  name             = "metrics-server"
+  repository       = "https://kubernetes-sigs.github.io/metrics-server/"
+  chart            = "metrics-server"
+  namespace        = var.helm_config.namespace
+  version          = var.helm_config.version
+  create_namespace = var.helm_config.create_namespace
+  cleanup_on_fail  = true
 
-  name            = "metrics-server"
-  repository      = "https://kubernetes-sigs.github.io/metrics-server/"
-  chart           = "metrics-server"
-  namespace       = "kube-system"
-  version         = "3.13.0"
-  cleanup_on_fail = true
-
-  values = [
-    # Allow the chart metrics-server to connect to the kubelet's metrics endpoint
-    yamlencode({
-      # Will be fixed soon
-      args = ["--kubelet-insecure-tls"]
-    })
+  set = [
+    {
+      name  = "image.repository"
+      value = "${var.helm_config.image_registry}/${var.helm_config.image_repository}/metrics-server"
+    },
+    {
+      name  = "args[0]"
+      value = "--kubelet-insecure-tls"
+    }
   ]
 }

--- a/terraform/modules/kubernetes-addons/metric-server/variables.tf
+++ b/terraform/modules/kubernetes-addons/metric-server/variables.tf
@@ -1,0 +1,20 @@
+
+variable "helm_config" {
+  description = "Metrics Server Helm Chart installation configuration"
+  type = object({
+    install          = bool
+    version          = string
+    namespace        = string
+    create_namespace = bool
+    image_registry   = string
+    image_repository = string
+  })
+  default = {
+    install          = true
+    version          = "3.13.0"
+    namespace        = "kube-system"
+    create_namespace = true
+    image_registry   = "registry.k8s.io"
+    image_repository = "metrics-server"
+  }
+}

--- a/terraform/modules/kubernetes-addons/platform-trust-engine/providers.tf
+++ b/terraform/modules/kubernetes-addons/platform-trust-engine/providers.tf
@@ -5,5 +5,9 @@ terraform {
       source  = "gavinbunney/kubectl"
       version = "1.19.0"
     }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "5.5.0"
+    }
   }
 }

--- a/terraform/modules/kubernetes-addons/platform-trust-engine/resources.tf
+++ b/terraform/modules/kubernetes-addons/platform-trust-engine/resources.tf
@@ -39,8 +39,8 @@ resource "kubernetes_secret" "vault_reviewer_token" {
 # Configure Vault's Kubernetes Auth Method that K8s Host, CA and Reviewer Token are injected into Vault
 resource "vault_kubernetes_auth_backend_config" "config" {
   backend                = var.vault_config.auth_path
-  kubernetes_host        = var.k8s_connection.host
-  kubernetes_ca_cert     = var.k8s_connection.ca_cert
+  kubernetes_host        = var.api_server_connection.host
+  kubernetes_ca_cert     = var.api_server_connection.ca_cert
   token_reviewer_jwt     = kubernetes_secret.vault_reviewer_token.data["token"]
   disable_iss_validation = true
 }
@@ -59,6 +59,22 @@ resource "helm_release" "cert_manager" {
     {
       name  = "installCRDs"
       value = "true"
+    },
+    {
+      name  = "image.repository"
+      value = "${var.helm_config.image_registry}/${var.helm_config.image_repository}/cert-manager-controller"
+    },
+    {
+      name  = "webhook.image.repository"
+      value = "${var.helm_config.image_registry}/${var.helm_config.image_repository}/cert-manager-webhook"
+    },
+    {
+      name  = "cainjector.image.repository"
+      value = "${var.helm_config.image_registry}/${var.helm_config.image_repository}/cert-manager-cainjector"
+    },
+    {
+      name  = "startupapicheck.image.repository"
+      value = "${var.helm_config.image_registry}/${var.helm_config.image_repository}/cert-manager-startupapicheck"
     }
   ]
 }

--- a/terraform/modules/kubernetes-addons/platform-trust-engine/variables.tf
+++ b/terraform/modules/kubernetes-addons/platform-trust-engine/variables.tf
@@ -1,5 +1,5 @@
 
-variable "k8s_connection" {
+variable "api_server_connection" {
   description = "Connection information of Kubernetes API Server, used for Vault authentication callback"
   type = object({
     host    = string
@@ -52,11 +52,15 @@ variable "helm_config" {
     version          = string
     namespace        = string
     create_namespace = bool
+    image_registry   = string
+    image_repository = string
   })
   default = {
     install          = true
     version          = "v1.14.0"
     namespace        = "cert-manager"
     create_namespace = true
+    image_registry   = "quay.io"
+    image_repository = "jetstack"
   }
 }

--- a/terraform/modules/kubernetes-addons/tigera-calico/main.tf
+++ b/terraform/modules/kubernetes-addons/tigera-calico/main.tf
@@ -21,12 +21,12 @@ resource "helm_release" "tigera_operator" {
     yamlencode({
       tigeraOperator = {
         registry = var.image_registry
-        image    = var.image_path != null ? "${var.image_path}/tigera/operator" : "tigera/operator"
+        image    = join("/", compact([var.image_path, "tigera/operator"]))
       }
       installation = {
         enabled            = true
         kubernetesProvider = ""
-        registry           = var.image_path != null ? "${var.image_registry}/${var.image_path}/" : "${var.image_registry}/"
+        registry           = "${join("/", compact([var.image_registry, var.image_path]))}"
         imagePath          = ""
         cni = {
           type = "Calico"

--- a/terraform/modules/kubernetes-addons/tigera-calico/main.tf
+++ b/terraform/modules/kubernetes-addons/tigera-calico/main.tf
@@ -19,8 +19,15 @@ resource "helm_release" "tigera_operator" {
   # Configure the Calico network through the operator's custom resources
   values = [
     yamlencode({
+      tigeraOperator = {
+        registry = var.image_registry
+        image    = var.image_path != null ? "${var.image_path}/tigera/operator" : "tigera/operator"
+      }
       installation = {
+        enabled            = true
         kubernetesProvider = ""
+        registry           = var.image_path != null ? "${var.image_registry}/${var.image_path}/" : "${var.image_registry}/"
+        imagePath          = ""
         cni = {
           type = "Calico"
         }

--- a/terraform/modules/kubernetes-addons/tigera-calico/variables.tf
+++ b/terraform/modules/kubernetes-addons/tigera-calico/variables.tf
@@ -1,4 +1,17 @@
+
 variable "pod_subnet" {
   type        = string
   description = "The CIDR block for the Kubernetes pod network."
+}
+
+variable "image_registry" {
+  type        = string
+  description = "The container registry to pull images from (e.g. harbor.iac.local)"
+  default     = "quay.io"
+}
+
+variable "image_path" {
+  type        = string
+  description = "The image path/project within the registry"
+  default     = null
 }


### PR DESCRIPTION

### Summary

This PR aims to refactor Kubernetes platform modules (Metrics-Server, Ingress-Nginx, Local-Path Provisioner) to use a standardized `helm_config` structure and redirection to Bootstrapper Harbor proxy. Implemented a unified local state management pattern in Layer 50 and resolved resource conflicts through cluster cleanup and state synchronization.

## Changes

### Core Architecture

1. **Standardized Module Interfaces**: Introduced `helm_config` object in all platform modules to decouple image and chart configuration from module logic.
2. **Unified State Management**: Implemented a centralized `state` local object in Layer 50 to aggregate remote state outputs, replacing direct `data.terraform_remote_state` calls.
3. **Harbor Proxy Integration**: Dynamic retrieval of Harbor proxy project names from the bootstrapper layer to ensure registry redirection consistency.

### Fixes & Technical Debt

- **ImagePullBackOff Errors**:
  - *Problem*: Incomplete image repository paths prevented successful pulls from Harbor.
  - *Solution*: Corrected image paths to include full hierarchy (e.g., `k8s-proxy/metrics-server/metrics-server`).
- **Ingress-Nginx Output Reliability**:
  - *Problem*: Accessing the `spec` of a null/empty service object during refresh caused Terraform crashes.
  - *Solution*: Implemented null-safety checks in `service_node_ports` output.

### Refactoring

- **Logic Decoupling**: Removed hardcoded strings and ternary logic from module definitions, shifting configuration responsibility to the calling layer.
- **State Access Normalization**: Consolidated all external remote state references into a single `local.state` object for improved readability and consistency.

### Verification

- [x] **Cluster Status**: All pods in `ingress-nginx`, `cert-manager`, and `kube-system` (metrics-server, local-path) are `Running`.
- [x] **Image Redirection**: Verified containers pull from `harbor-bootstrapper.production.iac.local` proxies.
- [x] **Vault Issuer**: Confirmed `ClusterIssuer` is `Ready` and functional.
- [x] **Idempotency**: Verified `tofu plan` returns `No changes` after architectural refactoring.