### PR TITLE
fix(tf/harbor/coredns): Enable Resource Creation for CoreDNS Configuration

### DIFF
--- a/terraform/modules/kubernetes-addons/coredns-config/resources.tf
+++ b/terraform/modules/kubernetes-addons/coredns-config/resources.tf
@@ -3,6 +3,9 @@ resource "kubernetes_config_map" "coredns_custom_config" {
   metadata {
     name      = "coredns"
     namespace = "kube-system"
+    labels = {
+      "k8s-app" = "kube-dns"
+    }
   }
 
   data = {

--- a/terraform/modules/kubernetes-addons/coredns-config/resources.tf
+++ b/terraform/modules/kubernetes-addons/coredns-config/resources.tf
@@ -1,12 +1,9 @@
 
-resource "kubernetes_config_map_v1_data" "coredns_custom_config" {
-
+resource "kubernetes_config_map" "coredns_custom_config" {
   metadata {
     name      = "coredns"
     namespace = "kube-system"
   }
-
-  force = true
 
   data = {
     Corefile = local.final_corefile


### PR DESCRIPTION

### Fixes & Technical Debt

**Problem:** CoreDNS Pods were stuck in `ContainerCreating` after a node reboot because the `coredns` ConfigMap was missing in the `kube-system` namespace. This occurred because L30 Ansible removes the default ConfigMap to allow adoption, but the `coredns-config` module used `kubernetes_config_map_v1_data`, which only supports patching existing resources and cannot create them if they are missing.

**Solution:** Changed the resource type in `terraform/modules/kubernetes-addons/coredns-config/resources.tf` from `kubernetes_config_map_v1_data` to `kubernetes_config_map`.

**Effect:**
- Allows Terraform to manage the full lifecycle of the `coredns` ConfigMap.
- Automatically recreates the ConfigMap if it is missing, ensuring CoreDNS can always mount its configuration and start successfully.
- Verified that `harbor.production.iac.local` resolves correctly after the change.