### PR TITLE
refactor(ansible/dist-harbor-provision): Harbor Infrastructure Provisioning - Phase 1

### DIFF
--- a/ansible/roles/30-microk8s-prerequisites/tasks/main.yaml
+++ b/ansible/roles/30-microk8s-prerequisites/tasks/main.yaml
@@ -70,10 +70,6 @@
         _etc_hosts_list: >-
           {{ ([{'host': registry_host, 'ip': registry_vip}] +
               (node_extra_hosts | default([]))) | unique(attribute='host') }}
-        _registry_domains: >-
-          {{ ([registry_host, registry_vip] +
-              (node_extra_hosts | default([]) | map(attribute='host') | list) +
-              ['docker.io', 'registry.k8s.io', 'quay.io']) | unique }}
         _containerd_registry_configs: "{{ lookup('template', 'containerd_registry_configs.j2') | from_yaml }}"
 
     - name: "Step B2. Ensure local DNS overrides for Registries in /etc/hosts"
@@ -86,12 +82,12 @@
 
     - name: "Step B3. Ensure Mirror Directories Exist"
       ansible.builtin.file:
-        path: "/var/snap/microk8s/current/args/certs.d/{{ item }}"
+        path: "/var/snap/microk8s/current/args/certs.d/{{ item.domain }}"
         state: directory
         owner: root
         group: root
         mode: "0755"
-      loop: "{{ _registry_domains }}"
+      loop: "{{ _containerd_registry_configs }}"
 
     - name: "Step B4. Deploy hosts.toml (Standard Registry & Inception redirection)"
       ansible.builtin.template:

--- a/ansible/roles/30-microk8s-prerequisites/tasks/main.yaml
+++ b/ansible/roles/30-microk8s-prerequisites/tasks/main.yaml
@@ -37,7 +37,7 @@
           via {{ ansible_default_ipv4.gateway }}
           dev {{ ansible_default_ipv4.interface }}
           advmss 1300
-      when: item.rc != 0
+      changed_when: item.rc != 0
       loop: "{{ route_check.results }}"
       loop_control:
         label: "{{ item.item }}"
@@ -65,29 +65,18 @@
 - name: "Block B: Configure Containerd Registry endpoint (MicroK8s Snap)"
   become: true
   block:
-    - name: "Step B0.1. Pre-calculate Registry Configurations"
+    - name: "Step B1. Pre-calculate Registry Configurations"
       ansible.builtin.set_fact:
-        _etc_hosts_list: "{{ ([{'host': registry_host, 'ip': registry_vip}] + (node_extra_hosts | default([]))) | unique(attribute='host') }}"
-        _registry_domains: "{{ ([registry_host, registry_vip] + (node_extra_hosts | default([]) | map(attribute='host') | list) + ['docker.io', 'registry.k8s.io', 'quay.io']) | unique }}"
-        _containerd_registry_configs: "{{ _raw_configs | from_yaml }}"
-      vars:
-        _raw_configs: |
-          {% set base = [
-            {'domain': registry_host, 'upstream': registry_host},
-            {'domain': registry_vip, 'upstream': registry_host}
-          ] %}
-          {% set extras = [] %}
-          {% for item in (node_extra_hosts | default([])) %}
-            {% set _ = extras.append({'domain': item.host, 'upstream': item.host}) %}
-          {% endfor %}
-          {% set proxies = [
-            {'domain': 'docker.io', 'upstream': 'registry-1.docker.io', 'proxy': harbor_docker_proxy, 'mirror_host': registry_host},
-            {'domain': 'registry.k8s.io', 'upstream': 'registry.k8s.io', 'proxy': harbor_k8s_proxy, 'mirror_host': registry_host},
-            {'domain': 'quay.io', 'upstream': 'quay.io', 'proxy': harbor_quay_proxy, 'mirror_host': registry_host}
-          ] %}
-          {{ base + extras + proxies }}
+        _etc_hosts_list: >-
+          {{ ([{'host': registry_host, 'ip': registry_vip}] +
+              (node_extra_hosts | default([]))) | unique(attribute='host') }}
+        _registry_domains: >-
+          {{ ([registry_host, registry_vip] +
+              (node_extra_hosts | default([]) | map(attribute='host') | list) +
+              ['docker.io', 'registry.k8s.io', 'quay.io']) | unique }}
+        _containerd_registry_configs: "{{ lookup('template', 'containerd_registry_configs.j2') | from_yaml }}"
 
-    - name: "Step B0.2. Ensure local DNS overrides for Registries in /etc/hosts"
+    - name: "Step B2. Ensure local DNS overrides for Registries in /etc/hosts"
       ansible.builtin.lineinfile:
         path: /etc/hosts
         regexp: '^.*\s+{{ item.host | regex_escape() }}(\s+|$)'
@@ -95,7 +84,7 @@
         state: present
       loop: "{{ _etc_hosts_list }}"
 
-    - name: "Step B1. Ensure Mirror Directories Exist"
+    - name: "Step B3. Ensure Mirror Directories Exist"
       ansible.builtin.file:
         path: "/var/snap/microk8s/current/args/certs.d/{{ item }}"
         state: directory
@@ -104,7 +93,7 @@
         mode: "0755"
       loop: "{{ _registry_domains }}"
 
-    - name: "Step B2. Deploy hosts.toml (Standard Registry & Inception redirection)"
+    - name: "Step B4. Deploy hosts.toml (Standard Registry & Inception redirection)"
       ansible.builtin.template:
         src: hosts.toml.j2
         dest: "/var/snap/microk8s/current/args/certs.d/{{ item.domain }}/hosts.toml"

--- a/ansible/roles/30-microk8s-prerequisites/tasks/main.yaml
+++ b/ansible/roles/30-microk8s-prerequisites/tasks/main.yaml
@@ -65,12 +65,35 @@
 - name: "Block B: Configure Containerd Registry endpoint (MicroK8s Snap)"
   become: true
   block:
-    - name: "Step B0. Ensure local DNS override for Harbor Bootstrapper Registry in /etc/hosts"
+    - name: "Step B0.1. Pre-calculate Registry Configurations"
+      ansible.builtin.set_fact:
+        _etc_hosts_list: "{{ ([{'host': registry_host, 'ip': registry_vip}] + (node_extra_hosts | default([]))) | unique(attribute='host') }}"
+        _registry_domains: "{{ ([registry_host, registry_vip] + (node_extra_hosts | default([]) | map(attribute='host') | list) + ['docker.io', 'registry.k8s.io', 'quay.io']) | unique }}"
+        _containerd_registry_configs: "{{ _raw_configs | from_yaml }}"
+      vars:
+        _raw_configs: |
+          {% set base = [
+            {'domain': registry_host, 'upstream': registry_host},
+            {'domain': registry_vip, 'upstream': registry_host}
+          ] %}
+          {% set extras = [] %}
+          {% for item in (node_extra_hosts | default([])) %}
+            {% set _ = extras.append({'domain': item.host, 'upstream': item.host}) %}
+          {% endfor %}
+          {% set proxies = [
+            {'domain': 'docker.io', 'upstream': 'registry-1.docker.io', 'proxy': harbor_docker_proxy, 'mirror_host': registry_host},
+            {'domain': 'registry.k8s.io', 'upstream': 'registry.k8s.io', 'proxy': harbor_k8s_proxy, 'mirror_host': registry_host},
+            {'domain': 'quay.io', 'upstream': 'quay.io', 'proxy': harbor_quay_proxy, 'mirror_host': registry_host}
+          ] %}
+          {{ base + extras + proxies }}
+
+    - name: "Step B0.2. Ensure local DNS overrides for Registries in /etc/hosts"
       ansible.builtin.lineinfile:
         path: /etc/hosts
-        regexp: '^.*\s+{{ registry_host | regex_escape() }}(\s+|$)'
-        line: "{{ registry_vip }} {{ registry_host }}"
+        regexp: '^.*\s+{{ item.host | regex_escape() }}(\s+|$)'
+        line: "{{ item.ip }} {{ item.host }}"
         state: present
+      loop: "{{ _etc_hosts_list }}"
 
     - name: "Step B1. Ensure Mirror Directories Exist"
       ansible.builtin.file:
@@ -79,12 +102,7 @@
         owner: root
         group: root
         mode: "0755"
-      loop:
-        - "{{ registry_host }}"
-        - "{{ registry_vip }}"
-        - "docker.io"
-        - "registry.k8s.io"
-        - "quay.io"
+      loop: "{{ _registry_domains }}"
 
     - name: "Step B2. Deploy hosts.toml (Standard Registry & Inception redirection)"
       ansible.builtin.template:
@@ -94,9 +112,4 @@
         group: root
         mode: "0644"
       notify: Restart MicroK8s Containerd
-      loop:
-        - { domain: "{{ registry_host }}", upstream_server: "{{ registry_host }}" }
-        - { domain: "{{ registry_vip }}", upstream_server: "{{ registry_host }}" }
-        - { domain: "docker.io", upstream_server: "registry-1.docker.io", proxy: "{{ harbor_docker_proxy }}" }
-        - { domain: "registry.k8s.io", upstream_server: "registry.k8s.io", proxy: "{{ harbor_k8s_proxy }}" }
-        - { domain: "quay.io", upstream_server: "quay.io", proxy: "{{ harbor_quay_proxy }}" }
+      loop: "{{ _containerd_registry_configs }}"

--- a/ansible/roles/30-microk8s-prerequisites/templates/containerd_registry_configs.j2
+++ b/ansible/roles/30-microk8s-prerequisites/templates/containerd_registry_configs.j2
@@ -1,0 +1,14 @@
+{% set base = [
+  {'domain': registry_host, 'upstream': registry_host},
+  {'domain': registry_vip, 'upstream': registry_host}
+] %}
+{% set extras = [] %}
+{% for item in (node_extra_hosts | default([])) %}
+  {% set _ = extras.append({'domain': item.host, 'upstream': item.host}) %}
+{% endfor %}
+{% set proxies = [
+  {'domain': 'docker.io', 'upstream': 'registry-1.docker.io', 'proxy': harbor_docker_proxy | default(''), 'mirror_host': registry_host},
+  {'domain': 'registry.k8s.io', 'upstream': 'registry.k8s.io', 'proxy': harbor_k8s_proxy | default(''), 'mirror_host': registry_host},
+  {'domain': 'quay.io', 'upstream': 'quay.io', 'proxy': harbor_quay_proxy | default(''), 'mirror_host': registry_host}
+] %}
+{{ base + extras + (proxies if (harbor_docker_proxy | default('')) != '' else []) }}

--- a/ansible/roles/30-microk8s-prerequisites/templates/containerd_registry_configs.j2
+++ b/ansible/roles/30-microk8s-prerequisites/templates/containerd_registry_configs.j2
@@ -10,5 +10,5 @@
   {'domain': 'docker.io', 'upstream': 'registry-1.docker.io', 'proxy': harbor_docker_proxy | default(''), 'mirror_host': registry_host},
   {'domain': 'registry.k8s.io', 'upstream': 'registry.k8s.io', 'proxy': harbor_k8s_proxy | default(''), 'mirror_host': registry_host},
   {'domain': 'quay.io', 'upstream': 'quay.io', 'proxy': harbor_quay_proxy | default(''), 'mirror_host': registry_host}
-] %}
-{{ base + extras + (proxies if (harbor_docker_proxy | default('')) != '' else []) }}
+] | selectattr('proxy', 'ne', '') | list %}
+{{ base + extras + proxies }}

--- a/ansible/roles/30-microk8s-prerequisites/templates/hosts.toml.j2
+++ b/ansible/roles/30-microk8s-prerequisites/templates/hosts.toml.j2
@@ -1,9 +1,10 @@
 
-server = "https://{{ item.upstream_server }}"
+server = "https://{{ item.upstream }}"
 
-[host."https://{{ registry_host }}{{ '/v2/' ~ item.proxy if item.proxy is defined else '' }}"]
+[host."https://{{ item.mirror_host | default(item.domain) }}{{ '/v2/' ~ item.proxy if item.proxy is defined else '' }}"]
     capabilities = ["pull", "resolve", "push"]
     skip_verify = false
+    ca = "/usr/local/share/ca-certificates/vault-pki-issuing-ca.crt"
 {% if item.proxy is defined %}
     override_path = true
 {% endif %}

--- a/ansible/roles/30-microk8s-prerequisites/templates/hosts.toml.j2
+++ b/ansible/roles/30-microk8s-prerequisites/templates/hosts.toml.j2
@@ -1,10 +1,10 @@
 
 server = "https://{{ item.upstream }}"
 
-[host."https://{{ item.mirror_host | default(item.domain) }}{{ '/v2/' ~ item.proxy if item.proxy is defined else '' }}"]
+[host."https://{{ item.mirror_host | default(item.domain) }}{{ '/v2/' ~ item.proxy if item.proxy | default('') != '' else '' }}"]
     capabilities = ["pull", "resolve", "push"]
     skip_verify = false
     ca = "/usr/local/share/ca-certificates/vault-pki-issuing-ca.crt"
-{% if item.proxy is defined %}
+{% if item.proxy | default('') != '' %}
     override_path = true
 {% endif %}

--- a/ansible/roles/34-kubeadm-prerequisites/tasks/main.yaml
+++ b/ansible/roles/34-kubeadm-prerequisites/tasks/main.yaml
@@ -40,12 +40,24 @@
 - name: "Block B: Configure Containerd Registry endpoint"
   become: true
   block:
-    - name: "Step B0. Ensure local DNS override for Harbor Bootstrapper Registry in /etc/hosts"
+    - name: "Step B0.1. Pre-calculate Registry Configurations"
+      ansible.builtin.set_fact:
+        _etc_hosts_list: >-
+          {{ ([{'host': kubeadm_registry_host, 'ip': kubeadm_registry_vip}] +
+              (node_extra_hosts | default([]))) | unique(attribute='host') }}
+        _registry_domains: >-
+          {{ ([kubeadm_registry_host, kubeadm_registry_vip] +
+              (node_extra_hosts | default([]) | map(attribute='host') | list) +
+              ['docker.io', 'registry.k8s.io', 'quay.io']) | unique }}
+        _containerd_registry_configs: "{{ lookup('template', 'containerd_registry_configs.j2') | from_yaml }}"
+
+    - name: "Step B0.2. Ensure local DNS overrides for Registries in /etc/hosts"
       ansible.builtin.lineinfile:
         path: /etc/hosts
-        regexp: '^.*\s+{{ kubeadm_registry_host | regex_escape() }}$'
-        line: "{{ kubeadm_registry_vip }} {{ kubeadm_registry_host }}"
+        regexp: '^.*\s+{{ item.host | regex_escape() }}(\s+|$)'
+        line: "{{ item.ip }} {{ item.host }}"
         state: present
+      loop: "{{ _etc_hosts_list }}"
 
     - name: "Step B1. Ensure /etc/containerd/certs.d directories exist"
       ansible.builtin.file:
@@ -54,18 +66,14 @@
         owner: root
         group: root
         mode: "0755"
-      loop:
-        - "{{ kubeadm_registry_host }}"
-        - "{{ kubeadm_registry_vip }}"
+      loop: "{{ _registry_domains }}"
 
     - name: "Step B2. Deploy hosts.toml for Harbor Registry"
       ansible.builtin.template:
         src: hosts.toml.j2
-        dest: "/etc/containerd/certs.d/{{ item }}/hosts.toml"
+        dest: "/etc/containerd/certs.d/{{ item.domain }}/hosts.toml"
         owner: root
         group: root
         mode: "0644"
       notify: Restart containerd service
-      loop:
-        - "{{ kubeadm_registry_host }}"
-        - "{{ kubeadm_registry_vip }}"
+      loop: "{{ _containerd_registry_configs }}"

--- a/ansible/roles/34-kubeadm-prerequisites/tasks/main.yaml
+++ b/ansible/roles/34-kubeadm-prerequisites/tasks/main.yaml
@@ -40,18 +40,14 @@
 - name: "Block B: Configure Containerd Registry endpoint"
   become: true
   block:
-    - name: "Step B0.1. Pre-calculate Registry Configurations"
+    - name: "Step B1. Pre-calculate Registry Configurations"
       ansible.builtin.set_fact:
         _etc_hosts_list: >-
           {{ ([{'host': kubeadm_registry_host, 'ip': kubeadm_registry_vip}] +
               (node_extra_hosts | default([]))) | unique(attribute='host') }}
-        _registry_domains: >-
-          {{ ([kubeadm_registry_host, kubeadm_registry_vip] +
-              (node_extra_hosts | default([]) | map(attribute='host') | list) +
-              ['docker.io', 'registry.k8s.io', 'quay.io']) | unique }}
         _containerd_registry_configs: "{{ lookup('template', 'containerd_registry_configs.j2') | from_yaml }}"
 
-    - name: "Step B0.2. Ensure local DNS overrides for Registries in /etc/hosts"
+    - name: "Step B2. Ensure local DNS overrides for Registries in /etc/hosts"
       ansible.builtin.lineinfile:
         path: /etc/hosts
         regexp: '^.*\s+{{ item.host | regex_escape() }}(\s+|$)'
@@ -59,16 +55,16 @@
         state: present
       loop: "{{ _etc_hosts_list }}"
 
-    - name: "Step B1. Ensure /etc/containerd/certs.d directories exist"
+    - name: "Step B3. Ensure Mirror Directories Exist"
       ansible.builtin.file:
-        path: "/etc/containerd/certs.d/{{ item }}"
+        path: "/etc/containerd/certs.d/{{ item.domain }}"
         state: directory
         owner: root
         group: root
         mode: "0755"
-      loop: "{{ _registry_domains }}"
+      loop: "{{ _containerd_registry_configs }}"
 
-    - name: "Step B2. Deploy hosts.toml for Harbor Registry"
+    - name: "Step B4. Deploy hosts.toml for Harbor Registry"
       ansible.builtin.template:
         src: hosts.toml.j2
         dest: "/etc/containerd/certs.d/{{ item.domain }}/hosts.toml"

--- a/ansible/roles/34-kubeadm-prerequisites/templates/containerd_registry_configs.j2
+++ b/ansible/roles/34-kubeadm-prerequisites/templates/containerd_registry_configs.j2
@@ -10,5 +10,5 @@
   {'domain': 'docker.io', 'upstream': 'registry-1.docker.io', 'proxy': harbor_docker_proxy | default(''), 'mirror_host': kubeadm_registry_host},
   {'domain': 'registry.k8s.io', 'upstream': 'registry.k8s.io', 'proxy': harbor_k8s_proxy | default(''), 'mirror_host': kubeadm_registry_host},
   {'domain': 'quay.io', 'upstream': 'quay.io', 'proxy': harbor_quay_proxy | default(''), 'mirror_host': kubeadm_registry_host}
-] %}
-{{ base + extras + (proxies if (harbor_docker_proxy | default('')) != '' else []) }}
+] | selectattr('proxy', 'ne', '') | list %}
+{{ base + extras + proxies }}

--- a/ansible/roles/34-kubeadm-prerequisites/templates/containerd_registry_configs.j2
+++ b/ansible/roles/34-kubeadm-prerequisites/templates/containerd_registry_configs.j2
@@ -1,0 +1,14 @@
+{% set base = [
+  {'domain': kubeadm_registry_host, 'upstream': kubeadm_registry_host},
+  {'domain': kubeadm_registry_vip, 'upstream': kubeadm_registry_host}
+] %}
+{% set extras = [] %}
+{% for item in (node_extra_hosts | default([])) %}
+  {% set _ = extras.append({'domain': item.host, 'upstream': item.host}) %}
+{% endfor %}
+{% set proxies = [
+  {'domain': 'docker.io', 'upstream': 'registry-1.docker.io', 'proxy': harbor_docker_proxy | default(''), 'mirror_host': kubeadm_registry_host},
+  {'domain': 'registry.k8s.io', 'upstream': 'registry.k8s.io', 'proxy': harbor_k8s_proxy | default(''), 'mirror_host': kubeadm_registry_host},
+  {'domain': 'quay.io', 'upstream': 'quay.io', 'proxy': harbor_quay_proxy | default(''), 'mirror_host': kubeadm_registry_host}
+] %}
+{{ base + extras + (proxies if (harbor_docker_proxy | default('')) != '' else []) }}

--- a/ansible/roles/34-kubeadm-prerequisites/templates/hosts.toml.j2
+++ b/ansible/roles/34-kubeadm-prerequisites/templates/hosts.toml.j2
@@ -1,10 +1,10 @@
 
 server = "https://{{ item.upstream }}"
 
-[host."https://{{ item.mirror_host | default(item.domain) }}{{ '/v2/' ~ item.proxy if item.proxy is defined else '' }}"]
+[host."https://{{ item.mirror_host | default(item.domain) }}{{ '/v2/' ~ item.proxy if item.proxy | default('') != '' else '' }}"]
     capabilities = ["pull", "resolve", "push"]
     skip_verify = false
     ca = "/usr/local/share/ca-certificates/vault-pki-issuing-ca.crt"
-{% if item.proxy is defined %}
+{% if item.proxy | default('') != '' %}
     override_path = true
 {% endif %}

--- a/ansible/roles/34-kubeadm-prerequisites/templates/hosts.toml.j2
+++ b/ansible/roles/34-kubeadm-prerequisites/templates/hosts.toml.j2
@@ -1,7 +1,10 @@
 
-server = "https://{{ kubeadm_registry_host }}"
+server = "https://{{ item.upstream }}"
 
-[host."https://{{ kubeadm_registry_host }}"]
+[host."https://{{ item.mirror_host | default(item.domain) }}{{ '/v2/' ~ item.proxy if item.proxy is defined else '' }}"]
     capabilities = ["pull", "resolve", "push"]
     skip_verify = false
+    ca = "/usr/local/share/ca-certificates/vault-pki-issuing-ca.crt"
+{% if item.proxy is defined %}
     override_path = true
+{% endif %}

--- a/terraform/layers/30-infra-gitlab-frontend/locals.tf
+++ b/terraform/layers/30-infra-gitlab-frontend/locals.tf
@@ -116,6 +116,14 @@ locals {
     # Port Mappings
     http_nodeport  = local.p_net_config.lb_config.ports["ingress-http"].backend_port
     https_nodeport = local.p_net_config.lb_config.ports["ingress-https"].backend_port
+
+    # Injected Host Overrides (Generic approach for PR 1)
+    node_extra_hosts = [
+      {
+        host = local.state.metadata.global_pki_map["harbor-frontend"].dns_san[0]
+        ip   = local.state.network.infrastructure_map["core-harbor-frontend"].lb_config.vip
+      }
+    ]
   }
 
   ansible_extra_vars = {
@@ -125,5 +133,10 @@ locals {
     vault_addr            = local.sys_vault_addr
     vault_role_name       = local.sec_vault_agent_identity.role_name
     service_name          = local.primary_context.s_name
+
+    # Mirroring Paths
+    harbor_docker_proxy = local.state.harbor_proxy.proxy_caches["docker_hub"].project_name
+    harbor_quay_proxy   = local.state.harbor_proxy.proxy_caches["quay_io"].project_name
+    harbor_k8s_proxy    = local.state.harbor_proxy.proxy_caches["k8s_io"].project_name
   }
 }

--- a/terraform/layers/30-infra-harbor-frontend/locals.tf
+++ b/terraform/layers/30-infra-harbor-frontend/locals.tf
@@ -89,6 +89,11 @@ locals {
     registry_host = local.state.metadata.global_pki_map[local.registry_pki_key].dns_san[0]
     registry_vip  = local.state.harbor_registry.service_vip
 
+    # Injected Host Overrides
+    node_extra_hosts = [
+      { host = local.svc_fqdn, ip = local.net_service_vip }
+    ]
+
     # Mirroring Paths
     harbor_docker_proxy = local.state.harbor_proxy.proxy_caches["docker_hub"].project_name
     harbor_quay_proxy   = local.state.harbor_proxy.proxy_caches["quay_io"].project_name

--- a/terraform/templates/inventory-kubeadm-cluster.yaml.tftpl
+++ b/terraform/templates/inventory-kubeadm-cluster.yaml.tftpl
@@ -14,6 +14,7 @@ all:
     kubeadm_registry_vip: "${custom_vars.registry_vip}"
     kubeadm_image_repository: "${custom_vars.image_repository}"
     kubeadm_dns_image_repository: "${custom_vars.image_repository}/coredns"
+    node_extra_hosts: ${jsonencode(custom_vars.node_extra_hosts)}
 
     kubeadm_http_nodeport: "${custom_vars.http_nodeport}"
     kubeadm_https_nodeport: "${custom_vars.https_nodeport}"

--- a/terraform/templates/inventory-microk8s-cluster.yaml.tftpl
+++ b/terraform/templates/inventory-microk8s-cluster.yaml.tftpl
@@ -18,6 +18,7 @@ all:
     harbor_docker_proxy: "${custom_vars.harbor_docker_proxy}"
     harbor_quay_proxy:   "${custom_vars.harbor_quay_proxy}"
     harbor_k8s_proxy:    "${custom_vars.harbor_k8s_proxy}"
+    node_extra_hosts:    ${jsonencode(custom_vars.node_extra_hosts)}
 
   children:
     nodes:


### PR DESCRIPTION

## Summary

The core objective of this PR is to settle "Post-hoc configuration" technical debt within the distributed architecture. By shifting node registry trust, DNS resolution, and environment initialization logic from the Application Layer (L60) forward to the Infrastructure Layer (L30), we achieve the declarative goal of nodes being "Born-ready."

## Changes

### Core Architecture

1.  **Registry Trust Generalization (L30)**: Decoupled registry trust (CA injection, Mirror routing) from the application lifecycle, re-aligning it with the host infrastructure lifecycle.
2.  **Infrastructure-Level DNS Injection**: Implemented global host resolution injection to ensure nodes can access the Bootstrapper and Production VIPs via `/etc/hosts` even before internal Kubernetes DNS is operational.
3.  **Unified Containerd Topology**: Standardized container runtime configuration styles across MicroK8s and Kubeadm to achieve cross-cluster environment consistency.

### Fixes & Technical Debt

- **Post-hoc Runtime Injection**:
    - _Problem_: The legacy architecture forcibly modified the system environment (e.g., `hosts.toml`) during the application deployment phase, leaving infrastructure nodes in a "half-baked" state during initialization and creating a hard dependency on the successful execution of L60 Playbooks.
    - _Solution_: Re-aligned trust anchors and routing configurations to the L30 Infrastructure Layer, ensuring environment security and connectivity are fully established before application execution.
- **Dynamic IP Discovery Antipattern**:
    - _Problem_: Using `kubectl` runtime probing in L60 to fetch Ingress IPs for backfilling `/etc/hosts` created a fragile circular dependency on cluster state.
    - _Solution_: Abolished dynamic probing in favor of the Terraform static network topology (Layer 05 Network State) as the Single Source of Truth (SSoT), explicitly injecting these during node deployment.
- **Fragmented Mirror Implementation**:
    - _Problem_: Nodes from different backgrounds (MicroK8s/Kubeadm) used mutually exclusive and hard-coded registry configuration logic, increasing maintenance overhead.
    - _Solution_: Generalized Containerd configuration logic by abstracting a three-tier mirror structure (`base/extras/proxies`), supporting future registry changes at any scale.

### Refactoring

- **Modular Template Logic**: Move embedded Jinja2 pre-computation logic into independent `.j2` templates. This reduces the complexity of Task files and ensures compliance with **Linting standards**.
- **SSoT Metadata Tracing**: Standardize the transfer path of complex objects from **Terraform to Ansible**, using JSON serialization to ensure the precise transmission of metadata such as `node_extra_hosts`.

### Verification

- [x] **Cluster Status**: Verified node availability in both clusters.
- [x] **Trust Anchor Persistence**: Verified Vault CA presence in `certs.d` across all target domains.

    ```bash
    # Kubeadm
    grep -rE "server|ca|host|proxy" /etc/containerd/certs.d/
    # Microk8s
    grep -rE "server|ca|host|proxy" /var/snap/microk8s/current/args/certs.d/
    ```

- [x] Confirmed the physical existence of the Vault PKI CA in the OS path; the key must be present:

    ```bash
    ls -l /usr/local/share/ca-certificates/vault-pki-issuing-ca.crt
    ```

- [x] **Inception Path Alignment**: Verified nodes resolve `harbor.production.iac.local` to VIP `131.250`.

    ```bash
    ping -c 1 harbor.production.iac.local
    ```