### PR TITLE
fix(cli/ghostty): Fix Terminal Compatibility and Update Infrastructure Secret Paths

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,8 +1,14 @@
+---
 extends: default
 
 rules:
+  comments:
+    min-spaces-from-content: 1
   braces:
     min-spaces-inside: 0
     max-spaces-inside: 1
   line-length:
     max: 125
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true

--- a/ansible/roles/00-base-common/tasks/main.yaml
+++ b/ansible/roles/00-base-common/tasks/main.yaml
@@ -28,3 +28,19 @@
       - jq
     state: present
     update_cache: true
+
+- name: "System: Install ncurses-term for terminfo support"
+  become: true
+  ansible.builtin.apt:
+    name: ncurses-term
+    state: present
+    update_cache: true
+
+- name: "System: Install Ghostty xterm-ghostty terminfo"
+  become: true
+  ansible.builtin.shell:
+    cmd: infocmp -x xterm-ghostty | tic -x -
+  args:
+    creates: /usr/share/terminfo/x/xterm-ghostty
+  when: ansible_os_family == "Debian"
+  changed_when: true

--- a/ansible/roles/00-base-common/tasks/main.yaml
+++ b/ansible/roles/00-base-common/tasks/main.yaml
@@ -26,13 +26,7 @@
       - bash-completion
       - python3-pip
       - jq
-    state: present
-    update_cache: true
-
-- name: "System: Install ncurses-term for terminfo support"
-  become: true
-  ansible.builtin.apt:
-    name: ncurses-term
+      - ncurses-term
     state: present
     update_cache: true
 

--- a/packer/00-base-os/build.pkr.hcl
+++ b/packer/00-base-os/build.pkr.hcl
@@ -55,7 +55,7 @@ build {
     ]
     extra_arguments = [
       "--extra-vars", "expected_hostname=${local.final_hostname}",
-      "--extra-vars", "public_key_file=${vault("secret/data/on-premise-gitlab-deployment/variables", "ssh_public_key_path")}",
+      "--extra-vars", "public_key_file=${vault("secret/data/on-premise-gitlab-deployment/guest_vm", "ssh_public_key_path")}",
       "--extra-vars", "ssh_user=${local.ssh_username}",
       "--extra-vars", "ansible_ssh_transfer_method=piped",
       "-v",

--- a/packer/00-base-os/build.pkr.hcl
+++ b/packer/00-base-os/build.pkr.hcl
@@ -55,7 +55,7 @@ build {
     ]
     extra_arguments = [
       "--extra-vars", "expected_hostname=${local.final_hostname}",
-      "--extra-vars", "public_key_file=${vault("secret/data/on-premise-gitlab-deployment/guest_vm", "ssh_public_key_path")}",
+      "--extra-vars", "public_key_file=${vault(var.secrets_path, "ssh_public_key_path")}",
       "--extra-vars", "ssh_user=${local.ssh_username}",
       "--extra-vars", "ansible_ssh_transfer_method=piped",
       "-v",

--- a/packer/00-base-os/source.pkr.hcl
+++ b/packer/00-base-os/source.pkr.hcl
@@ -2,9 +2,9 @@
 # This file defines the single, data-driven QEMU source for ISO-based installation.
 
 locals {
-  ssh_username        = vault("secret/data/on-premise-gitlab-deployment/variables", "ssh_username")
-  ssh_password        = vault("secret/data/on-premise-gitlab-deployment/variables", "ssh_password")
-  ssh_password_hash   = vault("secret/data/on-premise-gitlab-deployment/variables", "ssh_password_hash")
+  ssh_username        = vault("secret/data/on-premise-gitlab-deployment/guest_vm", "ssh_username")
+  ssh_password        = vault("secret/data/on-premise-gitlab-deployment/guest_vm", "ssh_password")
+  ssh_password_hash   = vault("secret/data/on-premise-gitlab-deployment/guest_vm", "ssh_password_hash")
 
   # The final hostname is simple.
   final_hostname = var.build_name

--- a/packer/00-base-os/source.pkr.hcl
+++ b/packer/00-base-os/source.pkr.hcl
@@ -2,9 +2,9 @@
 # This file defines the single, data-driven QEMU source for ISO-based installation.
 
 locals {
-  ssh_username        = vault("secret/data/on-premise-gitlab-deployment/guest_vm", "ssh_username")
-  ssh_password        = vault("secret/data/on-premise-gitlab-deployment/guest_vm", "ssh_password")
-  ssh_password_hash   = vault("secret/data/on-premise-gitlab-deployment/guest_vm", "ssh_password_hash")
+  ssh_username        = vault(var.secrets_path, "ssh_username")
+  ssh_password        = vault(var.secrets_path, "ssh_password")
+  ssh_password_hash   = vault(var.secrets_path, "ssh_password_hash")
 
   # The final hostname is simple.
   final_hostname = var.build_name

--- a/packer/00-base-os/variables.pkr.hcl
+++ b/packer/00-base-os/variables.pkr.hcl
@@ -43,3 +43,8 @@ variable "net_device" {
   type    = string
   default = "virtio-net"
 }
+
+variable "secrets_path" {
+  type = string
+  default = "secret/data/on-premise-gitlab-deployment/guest_vm"
+}

--- a/packer/10-services/build.pkr.hcl
+++ b/packer/10-services/build.pkr.hcl
@@ -29,7 +29,7 @@ build {
     ]
     extra_arguments = [
       "--extra-vars", "expected_hostname=${local.final_hostname}",
-      "--extra-vars", "public_key_file=${vault("secret/data/on-premise-gitlab-deployment/guest_vm", "ssh_public_key_path")}",
+      "--extra-vars", "public_key_file=${vault(var.secrets_path, "ssh_public_key_path")}",
       "--extra-vars", "ssh_user=${local.ssh_username}",
       "--extra-vars", "ansible_ssh_transfer_method=piped",
       "-v",

--- a/packer/10-services/build.pkr.hcl
+++ b/packer/10-services/build.pkr.hcl
@@ -29,7 +29,7 @@ build {
     ]
     extra_arguments = [
       "--extra-vars", "expected_hostname=${local.final_hostname}",
-      "--extra-vars", "public_key_file=${vault("secret/data/on-premise-gitlab-deployment/variables", "ssh_public_key_path")}",
+      "--extra-vars", "public_key_file=${vault("secret/data/on-premise-gitlab-deployment/guest_vm", "ssh_public_key_path")}",
       "--extra-vars", "ssh_user=${local.ssh_username}",
       "--extra-vars", "ansible_ssh_transfer_method=piped",
       "-v",

--- a/packer/10-services/source.pkr.hcl
+++ b/packer/10-services/source.pkr.hcl
@@ -2,9 +2,9 @@
 # This file defines the single, data-driven QEMU source for Disk-based (Backing file) builds.
 
 locals {
-  ssh_username        = vault("secret/data/on-premise-gitlab-deployment/variables", "ssh_username")
-  ssh_password        = vault("secret/data/on-premise-gitlab-deployment/variables", "ssh_password")
-  ssh_password_hash   = vault("secret/data/on-premise-gitlab-deployment/variables", "ssh_password_hash")
+  ssh_username        = vault("secret/data/on-premise-gitlab-deployment/guest_vm", "ssh_username")
+  ssh_password        = vault("secret/data/on-premise-gitlab-deployment/guest_vm", "ssh_password")
+  ssh_password_hash   = vault("secret/data/on-premise-gitlab-deployment/guest_vm", "ssh_password_hash")
 
   # The final hostname is simple.
   final_hostname = var.build_name

--- a/packer/10-services/source.pkr.hcl
+++ b/packer/10-services/source.pkr.hcl
@@ -2,9 +2,9 @@
 # This file defines the single, data-driven QEMU source for Disk-based (Backing file) builds.
 
 locals {
-  ssh_username        = vault("secret/data/on-premise-gitlab-deployment/guest_vm", "ssh_username")
-  ssh_password        = vault("secret/data/on-premise-gitlab-deployment/guest_vm", "ssh_password")
-  ssh_password_hash   = vault("secret/data/on-premise-gitlab-deployment/guest_vm", "ssh_password_hash")
+  ssh_username        = vault(var.secrets_path, "ssh_username")
+  ssh_password        = vault(var.secrets_path, "ssh_password")
+  ssh_password_hash   = vault(var.secrets_path, "ssh_password_hash")
 
   # The final hostname is simple.
   final_hostname = var.build_name

--- a/packer/10-services/variables.pkr.hcl
+++ b/packer/10-services/variables.pkr.hcl
@@ -52,3 +52,8 @@ variable "net_device" {
   type    = string
   default = "virtio-net"
 }
+
+variable "secrets_path" {
+  type = string
+  default = "secret/data/on-premise-gitlab-deployment/guest_vm"
+}


### PR DESCRIPTION
## Summary

This change primarily resolves the `unknown terminal type` error encountered when connecting to Ubuntu 24 virtual machines using the Ghostty terminal. It also synchronizes Vault secret paths within Packer scripts and strengthens YAML linting rules.

## Changes

### Core Architecture

1. **Ghostty Terminfo Integration**: Introduced `xterm-ghostty` support in the `00-base-common` Ansible Role to ensure terminal environments function correctly across modern CLI tools.
2. **Vault Secret Path Update**: Migrated Vault secret paths referenced in Packer source code from the legacy `variables` to `guest_vm`, aligning with current infrastructure secret management standards.

### Fixes & Technical Debt

- **[cli/ghostty]**:
    - *Problem*: When connecting via Ghostty terminal to a newly deployed guest VM, the lack of `xterm-ghostty` definition inside the VM prevents proper interface rendering or execution of interactive commands.
    - *Solution*: Installed the `ncurses-term` package and utilized `infocmp | tic` to dynamically compile and install the `xterm-ghostty` terminfo.
- **[packer/vault]**:
    - *Problem*: The legacy Vault secret path `secret/data/on-premise-gitlab-deployment/variables` has changed, causing Packer to fail in retrieving SSH users and passwords.
    - *Solution*: Corrected and parameterized the `vault` lookup paths in `build.pkr.hcl` and `source.pkr.hcl` to `guest_vm`.

### Refactoring

- **[Linter]**: Optimized `.yamllint.yml` configuration, primarily standardizing comment spacing and strictly prohibiting octal values to enhance readability and security of configuration files.

### Verification

- [x] Successfully deployed all Packer virtual machines.
- [x] Confirmed normal command execution after SSH entry into Guest VMs.