### PR TITLE
feat(oci/registry): Pivot Platform Helm Charts to Harbor Bootstrapper OCI Registry

### DIFF
--- a/README-zh-TW.md
+++ b/README-zh-TW.md
@@ -283,24 +283,25 @@ git clone --depth 1 https://github.com/csning1998-old/on-premise-gitlab-deployme
 
 ### C. Miscellaneous
 
-- **建議的 VSCode Plugin：** 主要是相關 syataxes highlighting 的支援而已：
-    1. Ansible language support extension. [Marketplace Link of Ansible](https://marketplace.visualstudio.com/items?itemName=redhat.ansible)
+**建議的 VSCode Plugin：** 主要是相關 syataxes highlighting 的支援而已：
 
-        ```shell
-        code --install-extension redhat.ansible
-        ```
+1. Ansible language support extension. [Marketplace Link of Ansible](https://marketplace.visualstudio.com/items?itemName=redhat.ansible)
 
-    2. HCL language support extension for Terraform. [Marketplace Link of HashiCorp HCL](https://marketplace.visualstudio.com/items?itemName=HashiCorp.HCL)
+    ```shell
+    code --install-extension redhat.ansible
+    ```
 
-        ```shell
-        code --install-extension HashiCorp.HCL
-        ```
+2. HCL language support extension for Terraform. [Marketplace Link of HashiCorp HCL](https://marketplace.visualstudio.com/items?itemName=HashiCorp.HCL)
 
-    3. Packer tool extension. [Marketplace Link of Packer Powertools](https://marketplace.visualstudio.com/items?itemName=szTheory.vscode-packer-powertools)
+    ```shell
+    code --install-extension HashiCorp.HCL
+    ```
 
-        ```shell
-        code --install-extension szTheory.vscode-packer-powertools
-        ```
+3. Packer tool extension. [Marketplace Link of Packer Powertools](https://marketplace.visualstudio.com/items?itemName=szTheory.vscode-packer-powertools)
+
+    ```shell
+    code --install-extension szTheory.vscode-packer-powertools
+    ```
 
 ## Section 2. Configuration
 
@@ -606,6 +607,56 @@ git clone --depth 1 https://github.com/csning1998-old/on-premise-gitlab-deployme
     - `entry.sh` 選項 `4` 做 Unseal Production mode Vault，會使用 Ansible Playbook `90-operation-vault-unseal.yaml` 操作
 
     或者如 B.1-2 所述使用容器，較為簡便
+
+6.  由於 Layer 50 相關的 Helm Chart 一律都採用 OCI 與 Bootstrapper Harbor 進行連線，因此需要先從遠端 `helm pull` 相關 Artifacts 並且推送到 Bootstrapper Harbor 中。要先確保 `30-infra-harbor-bootstrapper-frontend` 與 `40-provision-harbor-bootstrapper-frontend` 都有成功執行
+
+    在確定 L30 與 L40 有關 Bootstrapper Harbor 已執行之後，可以直接執行以下指令：
+    1. **環境變數相關以及登入**
+
+        ```bash
+        # 1. Environments
+        export VAULT_ADDR="https://172.16.136.250:443"
+        export VAULT_SKIP_VERIFY=true
+
+        ROLE_ID=$(sudo cat /etc/vault.d/approle/role_id)
+        SECRET_ID=$(sudo cat /etc/vault.d/approle/secret_id)
+
+        export HARBOR_REGISTRY="harbor-bootstrapper.production.iac.local"
+        export VAULT_TOKEN=$(vault write -field=token auth/workload-approle/login role_id="$ROLE_ID" secret_id="$SECRET_ID")
+        vault kv get -field=password_pusher secret/on-premise-gitlab-deployment/harbor-bootstrapper/robot | \
+        helm registry login "$HARBOR_REGISTRY" -u 'robot$helm-charts+helm-pusher' --password-stdin
+        ```
+
+    2. Pull 本次專案中相關的 Helm Chart，這是目前採用的版本
+
+        ```bash
+        helm pull ingress-nginx --version 4.10.0 --repo https://kubernetes.github.io/ingress-nginx
+        helm pull ingress-nginx --version 4.13.1 --repo https://kubernetes.github.io/ingress-nginx
+        helm pull metrics-server --version 3.13.0 --repo https://kubernetes-sigs.github.io/metrics-server/
+        helm pull oci://quay.io/jetstack/charts/cert-manager --version v1.14.0
+        helm pull oci://ghcr.io/rancher/local-path-provisioner/charts/local-path-provisioner --version 0.0.35
+        helm pull gitlab --version 9.8.2 --repo https://charts.gitlab.io/
+        helm pull tigera-operator --version v3.28.0 --repo https://docs.tigera.io/calico/charts
+        helm pull harbor --version 1.18.0 --repo https://helm.goharbor.io
+        ```
+
+    3. Push 剛剛取得的 Artifacts 到 `helm-charts`（預設）的 Porxy Project 內
+
+        ```bash
+        helm push ingress-nginx-4.10.0.tgz oci://"$HARBOR_REGISTRY"/helm-charts
+        helm push ingress-nginx-4.13.1.tgz oci://"$HARBOR_REGISTRY"/helm-charts
+        helm push metrics-server-3.13.0.tgz oci://"$HARBOR_REGISTRY"/helm-charts
+        helm push cert-manager-v1.14.0.tgz oci://"$HARBOR_REGISTRY"/helm-charts
+        helm push local-path-provisioner-0.0.35.tgz oci://"$HARBOR_REGISTRY"/helm-charts
+        helm push gitlab-9.8.2.tgz oci://"$HARBOR_REGISTRY"/helm-charts
+        helm push tigera-operator-v3.28.0.tgz oci://"$HARBOR_REGISTRY"/helm-charts
+        helm push harbor-1.18.0.tgz oci://"$HARBOR_REGISTRY"/helm-charts
+        ```
+
+    4. 後續才能執行 L50 的 Helm Chart
+
+> [!NOTE]
+> 如果要使用遠端來源，通常要設定 `terraform/modules/kubernetes-addons` 路徑中每一個 Helm Chart Module 的`repository` 與 `chart` 資訊。可以參考 #96 當時的 [程式碼紀錄](https://github.com/csning1998-old/on-premise-gitlab-deployment/tree/018233b3032e517b43e52fc4e17bcd3dde7cf52f/terraform/modules/kubernetes-addons)
 
 #### **Step B.3. Understand the Metadata:**
 

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Option `6` in `entry.sh` automates the installation of the QEMU/KVM environment.
 
 ### C. Miscellaneous
 
-- **Recommended VSCode Plugins:** These extensions provide syntax highlighting for the languages used in this project:
+**Recommended VSCode Plugins:** These extensions provide syntax highlighting for the languages used in this project:
 
 1. Ansible language support extension. [Marketplace Link of Ansible](https://marketplace.visualstudio.com/items?itemName=redhat.ansible)
 
@@ -605,6 +605,56 @@ Successful execution and the display of virtual machines—regardless of whether
     - Option `4` in `entry.sh` unseals Production Vault via `90-operation-vault-unseal.yaml` Ansible playbook.
 
     Alternatively, containerized approach described in B.1-2 is more streamlined.
+
+6. Since Helm Charts related to Layer 50 consistently utilize OCI to connect with Bootstrapper Harbor, it is necessary to first `helm pull` the relevant artifacts from remote repositories and push them to Bootstrapper Harbor. Ensure that `30-infra-harbor-bootstrapper-frontend` and `40-provision-harbor-bootstrapper-frontend` have been executed successfully.
+
+    Once it is confirmed that the Bootstrapper Harbor related L30 and L40 have been executed, you can directly run the following commands:
+    1. **Environment Variables and Login**
+
+        ```bash
+        # 1. Environments
+        export VAULT_ADDR="https://172.16.136.250:443"
+        export VAULT_SKIP_VERIFY=true
+
+        ROLE_ID=$(sudo cat /etc/vault.d/approle/role_id)
+        SECRET_ID=$(sudo cat /etc/vault.d/approle/secret_id)
+
+        export HARBOR_REGISTRY="harbor-bootstrapper.production.iac.local"
+        export VAULT_TOKEN=$(vault write -field=token auth/workload-approle/login role_id="$ROLE_ID" secret_id="$SECRET_ID")
+        vault kv get -field=password_pusher secret/on-premise-gitlab-deployment/harbor-bootstrapper/robot | \
+        helm registry login "$HARBOR_REGISTRY" -u 'robot$helm-charts+helm-pusher' --password-stdin
+        ```
+
+    2. Pull relevant Helm Charts for this project; these are the versions currently in use:
+
+        ```bash
+        helm pull ingress-nginx --version 4.10.0 --repo https://kubernetes.github.io/ingress-nginx
+        helm pull ingress-nginx --version 4.13.1 --repo https://kubernetes.github.io/ingress-nginx
+        helm pull metrics-server --version 3.13.0 --repo https://kubernetes-sigs.github.io/metrics-server/
+        helm pull oci://quay.io/jetstack/charts/cert-manager --version v1.14.0
+        helm pull oci://ghcr.io/rancher/local-path-provisioner/charts/local-path-provisioner --version 0.0.35
+        helm pull gitlab --version 9.8.2 --repo https://charts.gitlab.io/
+        helm pull tigera-operator --version v3.28.0 --repo https://docs.tigera.io/calico/charts
+        helm pull harbor --version 1.18.0 --repo https://helm.goharbor.io
+        ```
+
+    3. Push the retrieved artifacts to the `helm-charts` (default) Proxy Project:
+
+        ```bash
+        helm push ingress-nginx-4.10.0.tgz oci://"$HARBOR_REGISTRY"/helm-charts
+        helm push ingress-nginx-4.13.1.tgz oci://"$HARBOR_REGISTRY"/helm-charts
+        helm push metrics-server-3.13.0.tgz oci://"$HARBOR_REGISTRY"/helm-charts
+        helm push cert-manager-v1.14.0.tgz oci://"$HARBOR_REGISTRY"/helm-charts
+        helm push local-path-provisioner-0.0.35.tgz oci://"$HARBOR_REGISTRY"/helm-charts
+        helm push gitlab-9.8.2.tgz oci://"$HARBOR_REGISTRY"/helm-charts
+        helm push tigera-operator-v3.28.0.tgz oci://"$HARBOR_REGISTRY"/helm-charts
+        helm push harbor-1.18.0.tgz oci://"$HARBOR_REGISTRY"/helm-charts
+        ```
+
+    4. Subsequently, Layer 50 Helm Charts can be executed.
+
+> [!NOTE]
+> To use remote sources, typically the `repository` and `chart` information for each Helm Chart Module in the `terraform/modules/kubernetes-addons` path must be configured. Refer to the [code record](https://github.com/csning1998-old/on-premise-gitlab-deployment/tree/018233b3032e517b43e52fc4e17bcd3dde7cf52f/terraform/modules/kubernetes-addons) from #96.
 
 #### **Step B.3. Understand the Metadata:**
 

--- a/ansible/roles/29-dev-harbor-registry/defaults/main.yaml
+++ b/ansible/roles/29-dev-harbor-registry/defaults/main.yaml
@@ -17,3 +17,8 @@ vault_agent_config_dir: "/etc/vault.d"
 # Database and Harbor Admin Password from Vault
 harbor_bootstrapper_admin_password: "{{ harbor_vault_secrets.secret.harbor_bootstrapper_admin_password }}"
 harbor_bootstrapper_pg_db_password: "{{ harbor_vault_secrets.secret.harbor_bootstrapper_pg_db_password }}"
+
+# Helm Installation
+helm_version: "v3.14.3"
+helm_install_script_url: "https://raw.githubusercontent.com/helm/helm/{{ helm_version }}/scripts/get-helm-3"
+helm_install_script_checksum: "sha256:6701e269a95eec0a5f67067f504f43ad94e9b4a52ec1205d26b3973d6f5cb3dc"

--- a/ansible/roles/29-dev-harbor-registry/tasks/main.yaml
+++ b/ansible/roles/29-dev-harbor-registry/tasks/main.yaml
@@ -244,3 +244,17 @@
       until: result.status == 200
       retries: 30
       delay: 10
+
+- name: "Section G: Install Utilities for Artifact Management"
+  become: true
+  block:
+    - name: "Step G1. Download Helm installation script"
+      ansible.builtin.get_url:
+        url: https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+        dest: /tmp/get_helm.sh
+        mode: "0700"
+
+    - name: "Step G2. Execute Helm installation script"
+      ansible.builtin.command:
+        cmd: /tmp/get_helm.sh
+        creates: /usr/local/bin/helm

--- a/ansible/roles/29-dev-harbor-registry/tasks/main.yaml
+++ b/ansible/roles/29-dev-harbor-registry/tasks/main.yaml
@@ -60,18 +60,19 @@
       vars:
         vault_install_only: true
 
-    - name: "Step C2. Ensure Service Domain and FQDN resolve to Localhost"
+    - name: "Step C2. Ensure Service Domain resolves to Localhost for Vault Agent"
       ansible.builtin.lineinfile:
         path: /etc/hosts
-        line: "127.0.0.1 {{ dev_harbor_service_domain }} {{ dev_harbor_fqdn }}"
+        line: "127.0.0.1 {{ dev_harbor_service_domain }}"
         state: present
+        regexp: "^127.0.0.1 {{ dev_harbor_service_domain }}$"
 
     - name: "Step C2.1. Ensure Registry FQDN resolves to VIP for local operations"
       ansible.builtin.lineinfile:
         path: /etc/hosts
         line: "{{ dev_harbor_vip }} {{ dev_harbor_fqdn }}"
         state: present
-        regexp: "^.* {{ dev_harbor_fqdn }}$"
+        regexp: "^.* {{ dev_harbor_fqdn | replace('.', '\\.') }}$"
 
     - name: "Step C3. Create Vault Agent Config Directory"
       ansible.builtin.file:
@@ -257,11 +258,14 @@
   block:
     - name: "Step G1. Download Helm installation script"
       ansible.builtin.get_url:
-        url: https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+        url: "{{ helm_install_script_url }}"
         dest: /tmp/get_helm.sh
         mode: "0700"
+        checksum: "{{ helm_install_script_checksum }}"
 
     - name: "Step G2. Execute Helm installation script"
       ansible.builtin.command:
         cmd: /tmp/get_helm.sh
         creates: /usr/local/bin/helm
+      environment:
+        DESIRED_VERSION: "{{ helm_version }}"

--- a/ansible/roles/29-dev-harbor-registry/tasks/main.yaml
+++ b/ansible/roles/29-dev-harbor-registry/tasks/main.yaml
@@ -66,6 +66,13 @@
         line: "127.0.0.1 {{ dev_harbor_service_domain }} {{ dev_harbor_fqdn }}"
         state: present
 
+    - name: "Step C2.1. Ensure Registry FQDN resolves to VIP for local operations"
+      ansible.builtin.lineinfile:
+        path: /etc/hosts
+        line: "{{ dev_harbor_vip }} {{ dev_harbor_fqdn }}"
+        state: present
+        regexp: "^.* {{ dev_harbor_fqdn }}$"
+
     - name: "Step C3. Create Vault Agent Config Directory"
       ansible.builtin.file:
         path: "{{ vault_agent_config_dir }}/approle"

--- a/terraform/layers/30-infra-harbor-bootstrapper-frontend/locals.tf
+++ b/terraform/layers/30-infra-harbor-bootstrapper-frontend/locals.tf
@@ -101,11 +101,11 @@ locals {
 locals {
   ansible_template_vars = {
     access_scope        = local.network_infrastructure_map["default"].network.hostonly.cidr
-    dev_harbor_fqdn     = local.svc_fqdn
     dev_harbor_tls_port = local.network_infrastructure_map["default"].lb_config.ports["https"].frontend_port
-    dev_harbor_vip      = local.net_physical_infra.lb_config.vip
     nat_gateway         = local.network_infrastructure_map["default"].network.nat.gateway
     service_name        = local.svc_name
+    dev_harbor_fqdn     = local.svc_fqdn
+    dev_harbor_vip      = local.net_physical_infra.lb_config.vip
     vault_vip           = local.state.vault_sys.service_vip
   }
 

--- a/terraform/layers/40-provision-harbor-bootstrapper-frontend/locals.tf
+++ b/terraform/layers/40-provision-harbor-bootstrapper-frontend/locals.tf
@@ -10,6 +10,14 @@ locals {
 }
 
 locals {
+  proxy_oci = {
+    helm_charts = {
+      name = "helm-charts"
+    }
+  }
+}
+
+locals {
   proxy_caches = {
     docker_hub = {
       registry_name = "hub.docker.com"

--- a/terraform/layers/40-provision-harbor-bootstrapper-frontend/outputs.tf
+++ b/terraform/layers/40-provision-harbor-bootstrapper-frontend/outputs.tf
@@ -4,6 +4,11 @@ output "proxy_caches" {
   value       = local.proxy_caches
 }
 
+output "proxy_oci" {
+  description = "The Declared Harbor Projects for storing OCI images."
+  value       = local.proxy_oci
+}
+
 output "service_vip" {
   description = "The virtual IP assigned to the Bootstrap Harbor service from Central LB topology."
   value       = data.terraform_remote_state.harbor_bootstrapper.outputs.service_vip

--- a/terraform/layers/40-provision-harbor-bootstrapper-frontend/resources.tf
+++ b/terraform/layers/40-provision-harbor-bootstrapper-frontend/resources.tf
@@ -9,8 +9,8 @@ resource "harbor_registry" "proxy_registries" {
 resource "harbor_project" "proxy_projects" {
   for_each      = local.proxy_caches
   name          = each.value.project_name
-  public        = "true"
-  force_destroy = "true"
+  public        = true
+  force_destroy = true
   registry_id   = harbor_registry.proxy_registries[each.key].registry_id
 }
 
@@ -18,8 +18,8 @@ resource "harbor_project" "proxy_projects" {
 resource "harbor_project" "proxy_oci" {
   for_each      = local.proxy_oci
   name          = each.value.name
-  public        = "true"
-  force_destroy = "true"
+  public        = true
+  force_destroy = true
 }
 
 resource "harbor_robot_account" "helm_puller" {

--- a/terraform/layers/40-provision-harbor-bootstrapper-frontend/resources.tf
+++ b/terraform/layers/40-provision-harbor-bootstrapper-frontend/resources.tf
@@ -36,12 +36,32 @@ resource "harbor_robot_account" "helm_puller" {
   }
 }
 
-resource "vault_kv_secret_v2" "robot_helm_puller" {
+resource "harbor_robot_account" "helm_pusher" {
+  name        = "helm-pusher"
+  description = "Robot account for pushing Helm charts to OCI registry"
+  level       = "project"
+  permissions {
+    kind      = "project"
+    namespace = harbor_project.proxy_oci["helm_charts"].name
+    access {
+      action   = "push"
+      resource = "repository"
+    }
+    access {
+      action   = "pull"
+      resource = "repository"
+    }
+  }
+}
+
+resource "vault_kv_secret_v2" "robot_helm_creds" {
   provider = vault.production
   mount    = "secret"
   name     = "on-premise-gitlab-deployment/harbor-bootstrapper/robot"
   data_json = jsonencode({
-    username = harbor_robot_account.helm_puller.full_name
-    password = harbor_robot_account.helm_puller.secret
+    username_puller = harbor_robot_account.helm_puller.full_name
+    password_puller = harbor_robot_account.helm_puller.secret
+    username_pusher = harbor_robot_account.helm_pusher.full_name
+    password_pusher = harbor_robot_account.helm_pusher.secret
   })
 }

--- a/terraform/layers/40-provision-harbor-bootstrapper-frontend/resources.tf
+++ b/terraform/layers/40-provision-harbor-bootstrapper-frontend/resources.tf
@@ -1,17 +1,23 @@
 
 resource "harbor_registry" "proxy_registries" {
-  for_each = local.proxy_caches
-
+  for_each      = local.proxy_caches
   name          = each.value.registry_name
   endpoint_url  = each.value.endpoint_url
   provider_name = each.value.provider_name
 }
 
 resource "harbor_project" "proxy_projects" {
-  for_each = local.proxy_caches
-
+  for_each      = local.proxy_caches
   name          = each.value.project_name
   public        = "true"
-  force_destroy = true
+  force_destroy = "true"
   registry_id   = harbor_registry.proxy_registries[each.key].registry_id
+}
+
+
+resource "harbor_project" "proxy_oci" {
+  for_each      = local.proxy_oci
+  name          = each.value.name
+  public        = "true"
+  force_destroy = "true"
 }

--- a/terraform/layers/40-provision-harbor-bootstrapper-frontend/resources.tf
+++ b/terraform/layers/40-provision-harbor-bootstrapper-frontend/resources.tf
@@ -21,3 +21,27 @@ resource "harbor_project" "proxy_oci" {
   public        = "true"
   force_destroy = "true"
 }
+
+resource "harbor_robot_account" "helm_puller" {
+  name        = "helm-puller"
+  description = "Robot account for Helm Provider to pull charts"
+  level       = "project"
+  permissions {
+    kind      = "project"
+    namespace = harbor_project.proxy_oci["helm_charts"].name
+    access {
+      action   = "pull"
+      resource = "repository"
+    }
+  }
+}
+
+resource "vault_kv_secret_v2" "robot_helm_puller" {
+  provider = vault.production
+  mount    = "secret"
+  name     = "on-premise-gitlab-deployment/harbor-bootstrapper/robot"
+  data_json = jsonencode({
+    username = harbor_robot_account.helm_puller.full_name
+    password = harbor_robot_account.helm_puller.secret
+  })
+}

--- a/terraform/layers/50-platform-gitlab/data.tf
+++ b/terraform/layers/50-platform-gitlab/data.tf
@@ -67,6 +67,12 @@ data "terraform_remote_state" "harbor_bootstrapper" {
   }
 }
 
+# Harbor Bootstrapper Admin Credentials (for Helm OCI Registry)
+data "vault_generic_secret" "harbor_bootstrapper" {
+  provider = vault.production
+  path     = "secret/on-premise-gitlab-deployment/harbor-bootstrapper/app"
+}
+
 # 1. Database Provisioning State
 data "terraform_remote_state" "provision_databases" {
   backend = "local"

--- a/terraform/layers/50-platform-gitlab/data.tf
+++ b/terraform/layers/50-platform-gitlab/data.tf
@@ -101,3 +101,10 @@ data "vault_kv_secret_v2" "gitlab_s3" {
   mount    = "secret"
   name     = "on-premise-gitlab-deployment/gitlab/app/s3_credentials/${each.value}"
 }
+
+# Harbor Bootstrapper Robot Account (RBAC)
+data "vault_kv_secret_v2" "harbor_bootstrapper_robot" {
+  provider = vault.production
+  mount    = "secret"
+  name     = "on-premise-gitlab-deployment/harbor-bootstrapper/robot"
+}

--- a/terraform/layers/50-platform-gitlab/locals.tf
+++ b/terraform/layers/50-platform-gitlab/locals.tf
@@ -53,6 +53,7 @@ locals {
   harbor_k8s_proxy    = local.state.harbor_bootstrapper.proxy_caches.k8s_io.project_name
   harbor_docker_proxy = local.state.harbor_bootstrapper.proxy_caches.docker_hub.project_name
   harbor_gitlab_proxy = local.state.harbor_bootstrapper.proxy_caches.gitlab_com.project_name
+  helm_chart_project  = local.state.harbor_bootstrapper.proxy_oci.helm_charts.name
 
   # GitLab CNG image registry and repository routed through Harbor Bootstrapper proxy
   gitlab_image_registry   = local.harbor_registry

--- a/terraform/layers/50-platform-gitlab/main.tf
+++ b/terraform/layers/50-platform-gitlab/main.tf
@@ -4,6 +4,7 @@ module "tigera_calico" {
   pod_subnet     = local.state.kubeadm.kubernetes_config.pod_subnet
   image_registry = local.harbor_registry
   image_path     = local.harbor_quay_proxy
+  chart_project  = local.helm_chart_project
 }
 
 # [REFACTORED] Trust Engine Integration
@@ -51,6 +52,7 @@ module "platform_trust_engine" {
     image_registry   = local.harbor_registry
     image_repository = "${local.harbor_quay_proxy}/jetstack"
     chart_proxy      = local.harbor_quay_proxy
+    chart_project    = local.helm_chart_project
   }
 
   # Ensure CNI is ready before installing Cert-Manager
@@ -66,6 +68,7 @@ module "metric_server" {
     create_namespace = true
     image_registry   = local.harbor_registry
     image_repository = "${local.harbor_k8s_proxy}/metrics-server"
+    chart_project    = local.helm_chart_project
   }
   depends_on = [module.platform_trust_engine]
 }
@@ -79,6 +82,7 @@ module "ingress_nginx" {
     create_namespace = true
     image_registry   = local.harbor_registry
     image_repository = "${local.harbor_k8s_proxy}/ingress-nginx"
+    chart_project    = local.helm_chart_project
   }
   depends_on = [module.platform_trust_engine]
 }
@@ -93,6 +97,7 @@ module "storage_local_path" {
     image_registry          = local.harbor_registry
     image_repository        = "${local.harbor_docker_proxy}/rancher"
     helper_image_repository = "${local.harbor_docker_proxy}/library"
+    chart_project           = local.helm_chart_project
   }
   depends_on = [module.tigera_calico]
 }
@@ -129,6 +134,7 @@ module "gitlab_core" {
     namespace      = kubernetes_namespace.gitlab_ns.metadata[0].name
     timeout        = 900
     image_registry = local.harbor_registry
+    chart_project  = local.helm_chart_project
   }
 
   # GitLab Application Configuration

--- a/terraform/layers/50-platform-gitlab/main.tf
+++ b/terraform/layers/50-platform-gitlab/main.tf
@@ -50,6 +50,7 @@ module "platform_trust_engine" {
     create_namespace = true
     image_registry   = local.harbor_registry
     image_repository = "${local.harbor_quay_proxy}/jetstack"
+    chart_proxy      = local.harbor_quay_proxy
   }
 
   # Ensure CNI is ready before installing Cert-Manager
@@ -118,14 +119,16 @@ module "gitlab_core" {
     kubernetes_secret.gitlab_postgres_tls,
     kubernetes_namespace.gitlab_ns,
     module.coredns_config,
-    module.platform_trust_engine
+    module.platform_trust_engine,
+    module.ingress_nginx
   ]
 
   # Helm Deployment Configuration
   helm_config = {
-    version   = var.gitlab_helm_config.version
-    namespace = kubernetes_namespace.gitlab_ns.metadata[0].name
-    timeout   = 900
+    version        = var.gitlab_helm_config.version
+    namespace      = kubernetes_namespace.gitlab_ns.metadata[0].name
+    timeout        = 900
+    image_registry = local.harbor_registry
   }
 
   # GitLab Application Configuration

--- a/terraform/layers/50-platform-gitlab/providers.tf
+++ b/terraform/layers/50-platform-gitlab/providers.tf
@@ -67,8 +67,8 @@ provider "helm" {
   registries = [
     {
       url      = "oci://${local.harbor_registry}"
-      username = "admin"
-      password = data.vault_generic_secret.harbor_bootstrapper.data["harbor_bootstrapper_admin_password"]
+      username = data.vault_kv_secret_v2.harbor_bootstrapper_robot.data["username"]
+      password = data.vault_kv_secret_v2.harbor_bootstrapper_robot.data["password"]
     }
   ]
 }

--- a/terraform/layers/50-platform-gitlab/providers.tf
+++ b/terraform/layers/50-platform-gitlab/providers.tf
@@ -63,4 +63,12 @@ provider "helm" {
     client_certificate     = local.api_server_connection.client_certificate
     client_key             = local.api_server_connection.client_key
   }
+
+  registries = [
+    {
+      url      = "oci://${local.harbor_registry}"
+      username = "admin"
+      password = data.vault_generic_secret.harbor_bootstrapper.data["harbor_bootstrapper_admin_password"]
+    }
+  ]
 }

--- a/terraform/layers/50-platform-gitlab/providers.tf
+++ b/terraform/layers/50-platform-gitlab/providers.tf
@@ -67,8 +67,8 @@ provider "helm" {
   registries = [
     {
       url      = "oci://${local.harbor_registry}"
-      username = data.vault_kv_secret_v2.harbor_bootstrapper_robot.data["username"]
-      password = data.vault_kv_secret_v2.harbor_bootstrapper_robot.data["password"]
+      username = data.vault_kv_secret_v2.harbor_bootstrapper_robot.data["username_puller"]
+      password = data.vault_kv_secret_v2.harbor_bootstrapper_robot.data["password_puller"]
     }
   ]
 }

--- a/terraform/layers/50-platform-harbor/data.tf
+++ b/terraform/layers/50-platform-harbor/data.tf
@@ -60,6 +60,13 @@ data "terraform_remote_state" "harbor_bootstrapper" {
   }
 }
 
+# Harbor Bootstrapper Admin Credentials (for Helm OCI Registry)
+data "vault_kv_secret_v2" "harbor_bootstrapper_vars" {
+  provider = vault.production
+  mount    = "secret"
+  name     = "on-premise-gitlab-deployment/harbor-bootstrapper/app"
+}
+
 # 1. Fetch Harbor Secrets from Production Vault
 data "vault_kv_secret_v2" "db_vars" {
   provider = vault.production

--- a/terraform/layers/50-platform-harbor/data.tf
+++ b/terraform/layers/50-platform-harbor/data.tf
@@ -86,6 +86,13 @@ data "vault_kv_secret_v2" "s3_vars" {
   name     = "on-premise-gitlab-deployment/harbor/s3_credentials/harbor-registry"
 }
 
+# Harbor Bootstrapper Robot Account (RBAC)
+data "vault_kv_secret_v2" "harbor_bootstrapper_robot" {
+  provider = vault.production
+  mount    = "secret"
+  name     = "on-premise-gitlab-deployment/harbor-bootstrapper/robot"
+}
+
 # 2. Fetch Kubeconfig from Production Vault
 data "vault_kv_secret_v2" "kubeconfig" {
   provider = vault.production

--- a/terraform/layers/50-platform-harbor/locals.tf
+++ b/terraform/layers/50-platform-harbor/locals.tf
@@ -39,6 +39,9 @@ locals {
   harbor_k8s_proxy    = local.state.harbor_bootstrapper.proxy_caches.k8s_io.project_name
   harbor_docker_proxy = local.state.harbor_bootstrapper.proxy_caches.docker_hub.project_name
 
+  # Helm Charts Project (Sourced from Bootstrapper)
+  helm_chart_project = local.state.harbor_bootstrapper.proxy_oci.helm_charts.name
+
   # K8s API Endpoint for Vault Callback (Standardized)
   api_port     = local.state.metadata.global_topology_network["harbor"]["frontend"].ports["api-server"].frontend_port
   api_endpoint = "https://${local.state.microk8s_provision.harbor_microk8s_ip_list[0]}:${local.api_port}"

--- a/terraform/layers/50-platform-harbor/main.tf
+++ b/terraform/layers/50-platform-harbor/main.tf
@@ -43,6 +43,7 @@ module "platform_trust_engine" {
     create_namespace = true
     image_registry   = local.harbor_registry
     image_repository = "${local.harbor_quay_proxy}/jetstack"
+    chart_proxy      = local.harbor_quay_proxy
   }
 }
 
@@ -52,6 +53,7 @@ module "ingress_controller" {
 
   ingress_vip        = data.terraform_remote_state.microk8s_provision.outputs.harbor_microk8s_virtual_ip
   ingress_class_name = "nginx"
+  image_registry     = local.harbor_registry
 }
 
 # CoreDNS Configuration
@@ -80,9 +82,10 @@ module "harbor_core" {
   ca_bundle = local.ca_bundle_config
 
   helm_config = {
-    version   = var.harbor_helm_config.version
-    namespace = var.harbor_helm_config.namespace
-    timeout   = 600
+    version        = var.harbor_helm_config.version
+    namespace      = var.harbor_helm_config.namespace
+    timeout        = 600
+    image_registry = local.harbor_registry
   }
 
   certificate_config = var.certificate_config

--- a/terraform/layers/50-platform-harbor/main.tf
+++ b/terraform/layers/50-platform-harbor/main.tf
@@ -44,6 +44,7 @@ module "platform_trust_engine" {
     image_registry   = local.harbor_registry
     image_repository = "${local.harbor_quay_proxy}/jetstack"
     chart_proxy      = local.harbor_quay_proxy
+    chart_project    = local.helm_chart_project
   }
 }
 
@@ -54,6 +55,7 @@ module "ingress_controller" {
   ingress_vip        = data.terraform_remote_state.microk8s_provision.outputs.harbor_microk8s_virtual_ip
   ingress_class_name = "nginx"
   image_registry     = local.harbor_registry
+  chart_project      = local.helm_chart_project
 }
 
 # CoreDNS Configuration
@@ -86,6 +88,7 @@ module "harbor_core" {
     namespace      = var.harbor_helm_config.namespace
     timeout        = 600
     image_registry = local.harbor_registry
+    chart_project  = local.helm_chart_project
   }
 
   certificate_config = var.certificate_config

--- a/terraform/layers/50-platform-harbor/providers.tf
+++ b/terraform/layers/50-platform-harbor/providers.tf
@@ -66,8 +66,8 @@ provider "helm" {
   registries = [
     {
       url      = "oci://${local.harbor_registry}"
-      username = data.vault_kv_secret_v2.harbor_bootstrapper_robot.data["username"]
-      password = data.vault_kv_secret_v2.harbor_bootstrapper_robot.data["password"]
+      username = data.vault_kv_secret_v2.harbor_bootstrapper_robot.data["username_puller"]
+      password = data.vault_kv_secret_v2.harbor_bootstrapper_robot.data["password_puller"]
     }
   ]
 }

--- a/terraform/layers/50-platform-harbor/providers.tf
+++ b/terraform/layers/50-platform-harbor/providers.tf
@@ -62,6 +62,14 @@ provider "helm" {
     client_certificate     = local.api_server_connection.client_certificate
     client_key             = local.api_server_connection.client_key
   }
+
+  registries = [
+    {
+      url      = "oci://${local.harbor_registry}"
+      username = "admin"
+      password = data.vault_kv_secret_v2.harbor_bootstrapper_vars.data["harbor_bootstrapper_admin_password"]
+    }
+  ]
 }
 
 provider "harbor" {

--- a/terraform/layers/50-platform-harbor/providers.tf
+++ b/terraform/layers/50-platform-harbor/providers.tf
@@ -66,8 +66,8 @@ provider "helm" {
   registries = [
     {
       url      = "oci://${local.harbor_registry}"
-      username = "admin"
-      password = data.vault_kv_secret_v2.harbor_bootstrapper_vars.data["harbor_bootstrapper_admin_password"]
+      username = data.vault_kv_secret_v2.harbor_bootstrapper_robot.data["username"]
+      password = data.vault_kv_secret_v2.harbor_bootstrapper_robot.data["password"]
     }
   ]
 }

--- a/terraform/modules/kubernetes-addons/helm-chart-gitlab/main.tf
+++ b/terraform/modules/kubernetes-addons/helm-chart-gitlab/main.tf
@@ -1,7 +1,7 @@
 
 resource "helm_release" "gitlab" {
   name             = "gitlab"
-  chart            = "oci://${var.helm_config.image_registry}/helm-charts/gitlab"
+  chart            = "oci://${var.helm_config.image_registry}/${var.helm_config.chart_project}/gitlab"
   namespace        = var.helm_config.namespace
   version          = var.helm_config.version
   timeout          = var.helm_config.timeout

--- a/terraform/modules/kubernetes-addons/helm-chart-gitlab/main.tf
+++ b/terraform/modules/kubernetes-addons/helm-chart-gitlab/main.tf
@@ -1,8 +1,7 @@
 
 resource "helm_release" "gitlab" {
   name             = "gitlab"
-  chart            = "gitlab"
-  repository       = "https://charts.gitlab.io/"
+  chart            = "oci://${var.helm_config.image_registry}/helm-charts/gitlab"
   namespace        = var.helm_config.namespace
   version          = var.helm_config.version
   timeout          = var.helm_config.timeout

--- a/terraform/modules/kubernetes-addons/helm-chart-gitlab/variables.tf
+++ b/terraform/modules/kubernetes-addons/helm-chart-gitlab/variables.tf
@@ -6,6 +6,7 @@ variable "helm_config" {
     namespace      = string
     timeout        = number
     image_registry = string
+    chart_project  = string
   })
 }
 

--- a/terraform/modules/kubernetes-addons/helm-chart-gitlab/variables.tf
+++ b/terraform/modules/kubernetes-addons/helm-chart-gitlab/variables.tf
@@ -2,9 +2,10 @@
 variable "helm_config" {
   description = "Helm Chart deployment configuration"
   type = object({
-    version   = string
-    namespace = string
-    timeout   = number
+    version        = string
+    namespace      = string
+    timeout        = number
+    image_registry = string
   })
 }
 

--- a/terraform/modules/kubernetes-addons/helm-chart-harbor/helm-chart-official.tf
+++ b/terraform/modules/kubernetes-addons/helm-chart-harbor/helm-chart-official.tf
@@ -2,8 +2,7 @@
 # Harbor Helm Release
 resource "helm_release" "harbor" {
   name             = "harbor"
-  repository       = "https://helm.goharbor.io"
-  chart            = "harbor"
+  chart            = "oci://${var.helm_config.image_registry}/helm-charts/harbor"
   version          = var.helm_config.version
   namespace        = var.helm_config.namespace
   timeout          = var.helm_config.timeout

--- a/terraform/modules/kubernetes-addons/helm-chart-harbor/helm-chart-official.tf
+++ b/terraform/modules/kubernetes-addons/helm-chart-harbor/helm-chart-official.tf
@@ -2,7 +2,7 @@
 # Harbor Helm Release
 resource "helm_release" "harbor" {
   name             = "harbor"
-  chart            = "oci://${var.helm_config.image_registry}/helm-charts/harbor"
+  chart            = "oci://${var.helm_config.image_registry}/${var.helm_config.chart_project}/harbor"
   version          = var.helm_config.version
   namespace        = var.helm_config.namespace
   timeout          = var.helm_config.timeout

--- a/terraform/modules/kubernetes-addons/helm-chart-harbor/variables.tf
+++ b/terraform/modules/kubernetes-addons/helm-chart-harbor/variables.tf
@@ -6,6 +6,7 @@ variable "helm_config" {
     namespace      = string
     timeout        = number
     image_registry = string
+    chart_project  = string
   })
 }
 

--- a/terraform/modules/kubernetes-addons/helm-chart-harbor/variables.tf
+++ b/terraform/modules/kubernetes-addons/helm-chart-harbor/variables.tf
@@ -2,9 +2,10 @@
 variable "helm_config" {
   description = "Helm Chart deployment configuration"
   type = object({
-    version   = string
-    namespace = string
-    timeout   = number
+    version        = string
+    namespace      = string
+    timeout        = number
+    image_registry = string
   })
 }
 
@@ -14,7 +15,7 @@ variable "harbor_config" {
     hostname       = string
     notary_prefix  = string
     admin_password = string
-    secret_key     = string # 用於內部加密 (core-secret)
+    secret_key     = string # for internal encryption (core-secret)
   })
 }
 

--- a/terraform/modules/kubernetes-addons/ingress-nginx/main.tf
+++ b/terraform/modules/kubernetes-addons/ingress-nginx/main.tf
@@ -3,7 +3,7 @@ resource "helm_release" "ingress_nginx" {
   count = var.helm_config.install ? 1 : 0
 
   name             = "ingress-nginx"
-  chart            = "oci://${var.helm_config.image_registry}/helm-charts/ingress-nginx"
+  chart            = "oci://${var.helm_config.image_registry}/${var.helm_config.chart_project}/ingress-nginx"
   namespace        = var.helm_config.namespace
   create_namespace = var.helm_config.create_namespace
   version          = var.helm_config.version

--- a/terraform/modules/kubernetes-addons/ingress-nginx/main.tf
+++ b/terraform/modules/kubernetes-addons/ingress-nginx/main.tf
@@ -63,9 +63,6 @@ resource "helm_release" "ingress_nginx" {
             ]
           }
         }
-        admissionWebhooks = {
-          enabled = false
-        }
       }
     })
   ]

--- a/terraform/modules/kubernetes-addons/ingress-nginx/main.tf
+++ b/terraform/modules/kubernetes-addons/ingress-nginx/main.tf
@@ -3,8 +3,7 @@ resource "helm_release" "ingress_nginx" {
   count = var.helm_config.install ? 1 : 0
 
   name             = "ingress-nginx"
-  repository       = "https://kubernetes.github.io/ingress-nginx"
-  chart            = "ingress-nginx"
+  chart            = "oci://${var.helm_config.image_registry}/helm-charts/ingress-nginx"
   namespace        = var.helm_config.namespace
   create_namespace = var.helm_config.create_namespace
   version          = var.helm_config.version
@@ -63,6 +62,9 @@ resource "helm_release" "ingress_nginx" {
               }
             ]
           }
+        }
+        admissionWebhooks = {
+          enabled = false
         }
       }
     })

--- a/terraform/modules/kubernetes-addons/ingress-nginx/variables.tf
+++ b/terraform/modules/kubernetes-addons/ingress-nginx/variables.tf
@@ -8,13 +8,6 @@ variable "helm_config" {
     create_namespace = bool
     image_registry   = string
     image_repository = string
+    chart_project    = string
   })
-  default = {
-    install          = true
-    version          = "4.13.1"
-    namespace        = "ingress-nginx"
-    create_namespace = true
-    image_registry   = "registry.k8s.io"
-    image_repository = "ingress-nginx"
-  }
 }

--- a/terraform/modules/kubernetes-addons/local-path-provisioner/main.tf
+++ b/terraform/modules/kubernetes-addons/local-path-provisioner/main.tf
@@ -3,7 +3,7 @@ resource "helm_release" "local_path_provisioner" {
   count = var.helm_config.install ? 1 : 0
 
   name             = "local-path-storage"
-  chart            = "oci://${var.helm_config.image_registry}/helm-charts/local-path-provisioner"
+  chart            = "oci://${var.helm_config.image_registry}/${var.helm_config.chart_project}/local-path-provisioner"
   version          = var.helm_config.version
   namespace        = var.helm_config.namespace
   create_namespace = var.helm_config.create_namespace

--- a/terraform/modules/kubernetes-addons/local-path-provisioner/main.tf
+++ b/terraform/modules/kubernetes-addons/local-path-provisioner/main.tf
@@ -3,8 +3,7 @@ resource "helm_release" "local_path_provisioner" {
   count = var.helm_config.install ? 1 : 0
 
   name             = "local-path-storage"
-  repository       = "https://charts.containeroo.ch"
-  chart            = "local-path-provisioner"
+  chart            = "oci://${var.helm_config.image_registry}/helm-charts/local-path-provisioner"
   version          = var.helm_config.version
   namespace        = var.helm_config.namespace
   create_namespace = var.helm_config.create_namespace

--- a/terraform/modules/kubernetes-addons/local-path-provisioner/variables.tf
+++ b/terraform/modules/kubernetes-addons/local-path-provisioner/variables.tf
@@ -9,14 +9,6 @@ variable "helm_config" {
     image_registry          = string
     image_repository        = string
     helper_image_repository = string
+    chart_project           = string
   })
-  default = {
-    install                 = true
-    version                 = "0.0.35"
-    namespace               = "kube-system"
-    create_namespace        = true
-    image_registry          = "docker.io"
-    image_repository        = "rancher"
-    helper_image_repository = "library"
-  }
 }

--- a/terraform/modules/kubernetes-addons/local-path-provisioner/variables.tf
+++ b/terraform/modules/kubernetes-addons/local-path-provisioner/variables.tf
@@ -2,10 +2,10 @@
 variable "helm_config" {
   description = "Local Path Provisioner Helm Chart installation configuration"
   type = object({
-    install          = bool
-    version          = string
-    namespace        = string
-    create_namespace = bool
+    install                 = bool
+    version                 = string
+    namespace               = string
+    create_namespace        = bool
     image_registry          = string
     image_repository        = string
     helper_image_repository = string

--- a/terraform/modules/kubernetes-addons/metric-server/main.tf
+++ b/terraform/modules/kubernetes-addons/metric-server/main.tf
@@ -3,7 +3,7 @@ resource "helm_release" "metrics_server" {
   count = var.helm_config.install ? 1 : 0
 
   name             = "metrics-server"
-  chart            = "oci://${var.helm_config.image_registry}/helm-charts/metrics-server"
+  chart            = "oci://${var.helm_config.image_registry}/${var.helm_config.chart_project}/metrics-server"
   namespace        = var.helm_config.namespace
   version          = var.helm_config.version
   create_namespace = var.helm_config.create_namespace

--- a/terraform/modules/kubernetes-addons/metric-server/main.tf
+++ b/terraform/modules/kubernetes-addons/metric-server/main.tf
@@ -3,8 +3,7 @@ resource "helm_release" "metrics_server" {
   count = var.helm_config.install ? 1 : 0
 
   name             = "metrics-server"
-  repository       = "https://kubernetes-sigs.github.io/metrics-server/"
-  chart            = "metrics-server"
+  chart            = "oci://${var.helm_config.image_registry}/helm-charts/metrics-server"
   namespace        = var.helm_config.namespace
   version          = var.helm_config.version
   create_namespace = var.helm_config.create_namespace

--- a/terraform/modules/kubernetes-addons/metric-server/variables.tf
+++ b/terraform/modules/kubernetes-addons/metric-server/variables.tf
@@ -8,13 +8,6 @@ variable "helm_config" {
     create_namespace = bool
     image_registry   = string
     image_repository = string
+    chart_project    = string
   })
-  default = {
-    install          = true
-    version          = "3.13.0"
-    namespace        = "kube-system"
-    create_namespace = true
-    image_registry   = "registry.k8s.io"
-    image_repository = "metrics-server"
-  }
 }

--- a/terraform/modules/kubernetes-addons/microk8s-ingress/main.tf
+++ b/terraform/modules/kubernetes-addons/microk8s-ingress/main.tf
@@ -1,8 +1,7 @@
 
 resource "helm_release" "ingress_nginx" {
   name             = "ingress-nginx"
-  repository       = "https://kubernetes.github.io/ingress-nginx"
-  chart            = "ingress-nginx"
+  chart            = "oci://${var.image_registry}/helm-charts/ingress-nginx"
   namespace        = "ingress-system"
   create_namespace = true
   version          = "4.10.0"

--- a/terraform/modules/kubernetes-addons/microk8s-ingress/main.tf
+++ b/terraform/modules/kubernetes-addons/microk8s-ingress/main.tf
@@ -1,7 +1,7 @@
 
 resource "helm_release" "ingress_nginx" {
   name             = "ingress-nginx"
-  chart            = "oci://${var.image_registry}/helm-charts/ingress-nginx"
+  chart            = "oci://${var.image_registry}/${var.chart_project}/ingress-nginx"
   namespace        = "ingress-system"
   create_namespace = true
   version          = "4.10.0"

--- a/terraform/modules/kubernetes-addons/microk8s-ingress/variables.tf
+++ b/terraform/modules/kubernetes-addons/microk8s-ingress/variables.tf
@@ -14,3 +14,8 @@ variable "image_registry" {
   description = "The container image registry to pull OCI Helm charts from"
   type        = string
 }
+
+variable "chart_project" {
+  description = "The project name in Harbor for Helm charts"
+  type        = string
+}

--- a/terraform/modules/kubernetes-addons/microk8s-ingress/variables.tf
+++ b/terraform/modules/kubernetes-addons/microk8s-ingress/variables.tf
@@ -9,3 +9,8 @@ variable "ingress_class_name" {
   type        = string
   default     = "nginx"
 }
+
+variable "image_registry" {
+  description = "The container image registry to pull OCI Helm charts from"
+  type        = string
+}

--- a/terraform/modules/kubernetes-addons/platform-trust-engine/resources.tf
+++ b/terraform/modules/kubernetes-addons/platform-trust-engine/resources.tf
@@ -53,7 +53,6 @@ resource "helm_release" "cert_manager" {
   version          = var.helm_config.version
   namespace        = var.helm_config.namespace
   create_namespace = var.helm_config.create_namespace
-  # chart            = "${path.module}/charts/cert-manager-v1.14.0.tgz" # for ad-hoc and will be integrated using oci
 
   set = [
     {

--- a/terraform/modules/kubernetes-addons/platform-trust-engine/resources.tf
+++ b/terraform/modules/kubernetes-addons/platform-trust-engine/resources.tf
@@ -49,8 +49,7 @@ resource "vault_kubernetes_auth_backend_config" "config" {
 resource "helm_release" "cert_manager" {
   count            = var.helm_config.install ? 1 : 0
   name             = "cert-manager"
-  repository       = "https://charts.jetstack.io"
-  chart            = "cert-manager"
+  chart            = "oci://${var.helm_config.image_registry}/helm-charts/cert-manager"
   version          = var.helm_config.version
   namespace        = var.helm_config.namespace
   create_namespace = var.helm_config.create_namespace

--- a/terraform/modules/kubernetes-addons/platform-trust-engine/resources.tf
+++ b/terraform/modules/kubernetes-addons/platform-trust-engine/resources.tf
@@ -49,7 +49,7 @@ resource "vault_kubernetes_auth_backend_config" "config" {
 resource "helm_release" "cert_manager" {
   count            = var.helm_config.install ? 1 : 0
   name             = "cert-manager"
-  chart            = "oci://${var.helm_config.image_registry}/helm-charts/cert-manager"
+  chart            = "oci://${var.helm_config.image_registry}/${var.helm_config.chart_project}/cert-manager"
   version          = var.helm_config.version
   namespace        = var.helm_config.namespace
   create_namespace = var.helm_config.create_namespace

--- a/terraform/modules/kubernetes-addons/platform-trust-engine/variables.tf
+++ b/terraform/modules/kubernetes-addons/platform-trust-engine/variables.tf
@@ -54,13 +54,6 @@ variable "helm_config" {
     create_namespace = bool
     image_registry   = string
     image_repository = string
+    chart_project    = string
   })
-  default = {
-    install          = true
-    version          = "v1.14.0"
-    namespace        = "cert-manager"
-    create_namespace = true
-    image_registry   = "quay.io"
-    image_repository = "jetstack"
-  }
 }

--- a/terraform/modules/kubernetes-addons/tigera-calico/main.tf
+++ b/terraform/modules/kubernetes-addons/tigera-calico/main.tf
@@ -9,8 +9,7 @@ resource "kubernetes_namespace_v1" "tigera_operator" {
 # Install the tigera-operator directly using the repository URL
 resource "helm_release" "tigera_operator" {
   name             = "calico"
-  repository       = "https://docs.tigera.io/calico/charts"
-  chart            = "tigera-operator"
+  chart            = "oci://${var.image_registry}/helm-charts/tigera-operator"
   namespace        = kubernetes_namespace_v1.tigera_operator.metadata[0].name
   version          = "v3.28.0"
   create_namespace = false # The namespace is created explicitly above

--- a/terraform/modules/kubernetes-addons/tigera-calico/main.tf
+++ b/terraform/modules/kubernetes-addons/tigera-calico/main.tf
@@ -9,7 +9,7 @@ resource "kubernetes_namespace_v1" "tigera_operator" {
 # Install the tigera-operator directly using the repository URL
 resource "helm_release" "tigera_operator" {
   name             = "calico"
-  chart            = "oci://${var.image_registry}/helm-charts/tigera-operator"
+  chart            = "oci://${var.image_registry}/${var.chart_project}/tigera-operator"
   namespace        = kubernetes_namespace_v1.tigera_operator.metadata[0].name
   version          = "v3.28.0"
   create_namespace = false # The namespace is created explicitly above

--- a/terraform/modules/kubernetes-addons/tigera-calico/variables.tf
+++ b/terraform/modules/kubernetes-addons/tigera-calico/variables.tf
@@ -15,3 +15,8 @@ variable "image_path" {
   description = "The image path/project within the registry"
   default     = null
 }
+
+variable "chart_project" {
+  type        = string
+  description = "The project name in Harbor for Helm charts"
+}


### PR DESCRIPTION
## Summary

The primary objective of this PR is to transition the source of all platform Helm Charts to a local OCI registry hosted by the Harbor Bootstrapper, which is primarily intended to resolve frequent errors such as the following:

```text
│ Unable to locate chart cert-manager: looks like "https://charts.jetstack.io" is not a valid chart repository or
│ cannot be reached: read tcp [2001:b400:e245:58e2:3df7:3519:f67f:d662]:35476->[2606:4700::6812:1e78]:443: read:
│ connection reset by peer
```

This change centralizes Chart governance, eliminates external dependencies, and migrates authentication from the `admin` account to RBAC-enabled **Robot Accounts**.

## Changes

### Core Architecture

1. **Robot Account Provisioning**: Introduced `helm-puller` (Pull-only) and `helm-pusher` (Push/Pull) accounts in Layer 40 to achieve project-level permission isolation. Integrated Puller and Pusher credentials into a single Vault Secret object (`.../robot`).
2. **Dynamic Provider Authentication**: Updated Layer 50 (GitLab & Harbor Platform) to enable the Helm Provider to dynamically retrieve Robot credentials from Vault, completely removing hardcoded dependencies on administrator passwords.

### Refactoring

- **Variable Flow Optimization**: Injected `dev_harbor_vip` into Ansible template variables via Layer 30.
- **Unified Vault Credentials**: Consolidated Puller/Pusher credentials into a single Vault Secret node and aligned key-value pairs within the L50 Provider.

### Verification

- [x] **Cluster Status**: Verified Harbor API `/api/v2.0/health` returns `200 OK`.
- [x] **VIP Access**: Successfully executed `helm registry login` via FQDN using the `helm-pusher` account.
- [x] **Idempotency**: Verified that repeated `tofu apply` executions in Layers 30/40/50 result in no State Drift.
- [x] **Registry Access**: Confirmed successful Chart uploads to the Bootstrapper using `helm-pusher`.
- [x] **OCI Pull Verification**: Confirmed that GitLab/Harbor platform layers can successfully pull and start services from the OCI registry using Robot Accounts.