### PR TITLE
fix(pki-override): Metadata-Driven PKI Consolidation and Certificate Issuance Resolution

### DIFF
--- a/terraform/layers/00-foundation-metadata/locals-naming.tf
+++ b/terraform/layers/00-foundation-metadata/locals-naming.tf
@@ -58,13 +58,13 @@ locals {
       #    Supports multi-to-one mapping. Resolver is unidirectional and doesn't conflict with L7 routing.
       # 2. TLS/SSL Handshake Validation (RFC 5280/6066):
       #    Utilizes X.509 SAN extensions and SNI for domain-level isolation and certificate matching.
-      
+
       # Always include a deterministic default SAN for internal certificates.
       # Merge with any Ingress-defined SANs to ensure dns_san[0] is always safe.
       dns_san = distinct(concat(
         flatten([
           for i_key, i_data in coalesce(item.config.ingress, {}) : [
-            for sub in i_data.subdomains : 
+            for sub in i_data.subdomains :
             join(".", compact([
               sub,
               # Use conditional lookup to avoid ternary operator
@@ -88,6 +88,10 @@ locals {
       ]
 
       ttl_stage = item.stage
+      auth_config = {
+        method = contains(["kubeadm", "microk8s"], item.config.runtime) ? "kubernetes" : "approle"
+        path   = contains(["kubeadm", "microk8s"], item.config.runtime) ? "kubernetes-${item.cluster_name}" : "workload-approle"
+      }
     }
   ])
 

--- a/terraform/layers/20-security-vault-approle/locals.tf
+++ b/terraform/layers/20-security-vault-approle/locals.tf
@@ -12,28 +12,39 @@ locals {
 }
 
 locals {
-  admin_policy_rules = {
-    # [1] Data Plane (Business Data): Maintain strict least privilege,
-    #     precisely scoped to specific projects and mount points.
-    "secret/data/on-premise-gitlab-deployment/*"     = { capabilities = ["create", "read", "update", "delete"] }
-    "secret/metadata/on-premise-gitlab-deployment/*" = { capabilities = ["read", "list", "delete"] }
-    "secret/delete/on-premise-gitlab-deployment/*"   = { capabilities = ["update"] }
-    "secret/destroy/on-premise-gitlab-deployment/*"  = { capabilities = ["update"] }
+  # Extract unique authentication paths from metadata to avoid duplicate key errors
+  # during policy map construction (e.g., multiple baremetal components sharing 'workload-approle').
+  _all_auth_paths = distinct([for k, v in local.state.metadata.global_pki_map : v.auth_config.path])
 
-    "pki/prod/*"              = { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
-    "auth/kubernetes/*"       = { capabilities = ["create", "read", "update", "delete", "list"] }
-    "auth/workload-approle/*" = { capabilities = ["create", "read", "update", "delete", "list"] }
-
-    # [2] Control Plane (Administrative): Complies with Terraform official IaC management requirements.
-    #     Must allow global sys/mounts and sys/auth; otherwise, global routing table updates
-    #     and cascading revocations during 'destroy' operations cannot be executed.
-    "sys/mounts"   = { capabilities = ["read", "list"] }
-    "sys/mounts/*" = { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
-
-    "sys/auth"   = { capabilities = ["read", "list"] }
-    "sys/auth/*" = { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
-
-    # [3] Policy Management
-    "sys/policies/acl/*" = { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
+  # Dynamically generate administrative rules for all authentication backends defined in Metadata.
+  _auth_rules = {
+    for path in local._all_auth_paths :
+    "auth/${path}/*" => { capabilities = ["create", "read", "update", "delete", "list"] }
   }
+
+  admin_policy_rules = merge(
+    {
+      # [1] Data Plane (Business Data): Maintain strict least privilege,
+      #     precisely scoped to specific projects and mount points.
+      "secret/data/on-premise-gitlab-deployment/*"     = { capabilities = ["create", "read", "update", "delete"] }
+      "secret/metadata/on-premise-gitlab-deployment/*" = { capabilities = ["read", "list", "delete"] }
+      "secret/delete/on-premise-gitlab-deployment/*"   = { capabilities = ["update"] }
+      "secret/destroy/on-premise-gitlab-deployment/*"  = { capabilities = ["update"] }
+
+      "pki/prod/*" = { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
+
+      # [2] Control Plane (Administrative): Complies with Terraform official IaC management requirements.
+      #     Must allow global sys/mounts and sys/auth; otherwise, global routing table updates
+      #     and cascading revocations during 'destroy' operations cannot be executed.
+      "sys/mounts"   = { capabilities = ["read", "list"] }
+      "sys/mounts/*" = { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
+
+      "sys/auth"   = { capabilities = ["read", "list"] }
+      "sys/auth/*" = { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
+
+      # [3] Policy Management
+      "sys/policies/acl/*" = { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
+    },
+    local._auth_rules
+  )
 }

--- a/terraform/layers/25-security-pki/locals.tf
+++ b/terraform/layers/25-security-pki/locals.tf
@@ -72,3 +72,17 @@ locals {
     }
   }
 }
+# 4. Auth Backends Discovery
+locals {
+  # Extract unique authentication paths from metadata.
+  _auth_paths = distinct([for k, v in local.state.metadata.global_pki_map : v.auth_config.path])
+
+  # Map unique paths back to their respective methods.
+  _auth_backends = {
+    for path in local._auth_paths :
+    path => {
+      type = [for k, v in local.state.metadata.global_pki_map : v.auth_config.method if v.auth_config.path == path][0]
+      path = path
+    }
+  }
+}

--- a/terraform/layers/25-security-pki/locals.tf
+++ b/terraform/layers/25-security-pki/locals.tf
@@ -36,7 +36,7 @@ locals {
   component_roles = {
     for k, v in local.state.metadata.global_pki_map : k => {
       name            = v.role_name
-      allowed_domains = v.dns_san
+      allowed_domains = distinct(concat(v.dns_san, [local.root_domain]))
       ou              = v.ou
       max_ttl         = lookup(local.ttl_policy, v.ttl_stage, local.ttl_policy["default"]).max
       ttl             = lookup(local.ttl_policy, v.ttl_stage, local.ttl_policy["default"]).default
@@ -48,7 +48,7 @@ locals {
   dependency_roles = {
     for k, v in local.state.metadata.global_pki_map : k => {
       name            = v.role_name
-      allowed_domains = v.dns_san
+      allowed_domains = distinct(concat(v.dns_san, [local.root_domain]))
       ou              = v.ou
       max_ttl         = lookup(local.ttl_policy, v.ttl_stage, local.ttl_policy["default"]).max
       ttl             = lookup(local.ttl_policy, v.ttl_stage, local.ttl_policy["default"]).default

--- a/terraform/layers/25-security-pki/main.tf
+++ b/terraform/layers/25-security-pki/main.tf
@@ -34,21 +34,6 @@ module "vault_workload_identity_components" {
   name               = each.key
   vault_role_name    = each.value.name
   pki_mount_path     = module.vault_pki_setup.vault_pki_path
-  approle_mount_path = module.vault_pki_setup.auth_backend_paths["approle"]
+  approle_mount_path = module.vault_pki_setup.auth_backend_paths["workload-approle"]
   extra_policy_hcl   = lookup(local.workload_identity_extra_rules, each.key, {})
-}
-
-module "vault_workload_identity_dependencies" {
-
-  source = "../../modules/configuration/vault-workload-identity"
-  providers = {
-    vault = vault.production
-  }
-  depends_on = [module.vault_pki_setup]
-
-  for_each           = local.dependency_roles
-  name               = each.key
-  vault_role_name    = each.value.name
-  pki_mount_path     = module.vault_pki_setup.vault_pki_path
-  approle_mount_path = module.vault_pki_setup.auth_backend_paths["approle"]
 }

--- a/terraform/layers/25-security-pki/main.tf
+++ b/terraform/layers/25-security-pki/main.tf
@@ -15,7 +15,7 @@ module "vault_pki_setup" {
   root_domain         = local.root_domain
   root_ca_common_name = local.root_ca_common_name
 
-  auth_backends     = var.vault_auth_backends
+  auth_backends     = local._auth_backends
   pki_engine_config = var.vault_pki_engine_config
 
   component_roles  = local.component_roles

--- a/terraform/layers/25-security-pki/terraform.tfvars.example
+++ b/terraform/layers/25-security-pki/terraform.tfvars.example
@@ -4,9 +4,13 @@ vault_auth_backends = {
     type = "approle"
     path = "workload-approle"
   }
-  "kubernetes" = {
+  "kubernetes-gitlab-frontend" = {
     type = "kubernetes"
-    path = "kubernetes"
+    path = "kubernetes-gitlab-frontend"
+  }
+  "kubernetes-harbor-frontend" = {
+    type = "kubernetes"
+    path = "kubernetes-harbor-frontend"
   }
 }
 

--- a/terraform/layers/25-security-pki/terraform.tfvars.example
+++ b/terraform/layers/25-security-pki/terraform.tfvars.example
@@ -1,19 +1,4 @@
 
-vault_auth_backends = {
-  "approle" = {
-    type = "approle"
-    path = "workload-approle"
-  }
-  "kubernetes-gitlab-frontend" = {
-    type = "kubernetes"
-    path = "kubernetes-gitlab-frontend"
-  }
-  "kubernetes-harbor-frontend" = {
-    type = "kubernetes"
-    path = "kubernetes-harbor-frontend"
-  }
-}
-
 vault_pki_engine_config = {
   path                = "pki/prod"
   root_ca_common_name = "on-premise-gitlab-deployment-root-ca"

--- a/terraform/layers/25-security-pki/variables.tf
+++ b/terraform/layers/25-security-pki/variables.tf
@@ -1,12 +1,4 @@
 
-variable "vault_auth_backends" {
-  description = "Map of Auth Backends to enable (e.g., approle, kubernetes)"
-  type = map(object({
-    type = string
-    path = string
-  }))
-}
-
 variable "vault_pki_engine_config" {
   description = "Configuration for the PKI Secrets Engine"
   type = object({

--- a/terraform/layers/50-platform-gitlab/locals.tf
+++ b/terraform/layers/50-platform-gitlab/locals.tf
@@ -72,9 +72,9 @@ locals {
   vault_ca_cert  = local.state.vault_pki.bootstrap_ca.content
   vault_pki_path = local.state.vault_pki.pki_configuration.path
 
-  # Map to the specific component identity in Vault PKI
-  vault_role_name   = local.state.vault_pki.pki_configuration.component_roles["gitlab-frontend"].name
-  vault_auth_path   = local.state.vault_pki.auth_backend_paths["kubernetes"]
+  # Map to the specific component identity in Vault PKI (SSoT Driven)
+  vault_role_name = local.state.metadata.global_pki_map["gitlab-frontend"].role_name
+  vault_auth_path = local.state.metadata.global_pki_map["gitlab-frontend"].auth_config.path
   vault_policy_name = "${local.vault_role_name}-pki-policy"
 }
 

--- a/terraform/layers/50-platform-gitlab/main.tf
+++ b/terraform/layers/50-platform-gitlab/main.tf
@@ -51,7 +51,6 @@ module "platform_trust_engine" {
     create_namespace = true
     image_registry   = local.harbor_registry
     image_repository = "${local.harbor_quay_proxy}/jetstack"
-    chart_proxy      = local.harbor_quay_proxy
     chart_project    = local.helm_chart_project
   }
 

--- a/terraform/layers/50-platform-gitlab/main.tf
+++ b/terraform/layers/50-platform-gitlab/main.tf
@@ -140,7 +140,7 @@ module "gitlab_core" {
   gitlab_config = {
     hostname = local.fqdn_gitlab
     edition  = "ce"
-    # Root Password
+    dns_sans = local.state.metadata.global_pki_map["gitlab-frontend"].dns_san
   }
 
   # Trust Engine Integration

--- a/terraform/layers/50-platform-harbor/locals.tf
+++ b/terraform/layers/50-platform-harbor/locals.tf
@@ -58,9 +58,9 @@ locals {
   # Dependency Ports (Standardized)
   pg_port = local.state.metadata.global_topology_network["harbor"]["postgres"].ports["rw-proxy"].frontend_port
 
-  # Map to the specific component identity in Vault PKI
-  vault_role_name   = local.state.vault_pki.pki_configuration.component_roles["harbor-frontend"].name
-  vault_auth_path   = local.state.vault_pki.auth_backend_paths["kubernetes"]
+  # Map to the specific component identity in Vault PKI (SSoT Driven)
+  vault_role_name   = local.state.metadata.global_pki_map["harbor-frontend"].role_name
+  vault_auth_path   = local.state.metadata.global_pki_map["harbor-frontend"].auth_config.path
   vault_policy_name = "${local.vault_role_name}-pki-policy"
 }
 

--- a/terraform/layers/50-platform-harbor/main.tf
+++ b/terraform/layers/50-platform-harbor/main.tf
@@ -43,7 +43,6 @@ module "platform_trust_engine" {
     create_namespace = true
     image_registry   = local.harbor_registry
     image_repository = "${local.harbor_quay_proxy}/jetstack"
-    chart_proxy      = local.harbor_quay_proxy
     chart_project    = local.helm_chart_project
   }
 }

--- a/terraform/layers/50-platform-harbor/main.tf
+++ b/terraform/layers/50-platform-harbor/main.tf
@@ -97,6 +97,7 @@ module "harbor_core" {
     admin_password = local.harbor_admin_password
     notary_prefix  = var.harbor_helm_config.notary_prefix
     secret_key     = random_password.harbor_core_secret_key.result
+    dns_sans       = local.state.metadata.global_pki_map["harbor-frontend"].dns_san
   }
 
   ingress_config = {

--- a/terraform/modules/configuration/vault-pki-setup/roles-components.tf
+++ b/terraform/modules/configuration/vault-pki-setup/roles-components.tf
@@ -11,6 +11,7 @@ resource "vault_pki_secret_backend_role" "component_roles" {
   allow_glob_domains = false
   allow_ip_sans      = true
   allow_bare_domains = true
+  require_cn         = true
 
   key_usage = ["DigitalSignature", "KeyEncipherment", "KeyAgreement"]
 

--- a/terraform/modules/kubernetes-addons/helm-chart-gitlab/helm-chart-official.tf
+++ b/terraform/modules/kubernetes-addons/helm-chart-gitlab/helm-chart-official.tf
@@ -66,10 +66,12 @@ resource "helm_release" "gitlab" {
           configureCertmanager = false # use own secret
           class                = var.ingress_config.class_name
           annotations = {
-            "cert-manager.io/issuer"       = var.ingress_config.issuer_name
-            "cert-manager.io/issuer-kind"  = var.ingress_config.issuer_kind
-            "cert-manager.io/duration"     = var.certificate_config.duration
-            "cert-manager.io/renew-before" = var.certificate_config.renew_before
+            "cert-manager.io/issuer"                    = var.ingress_config.issuer_name
+            "cert-manager.io/issuer-kind"               = var.ingress_config.issuer_kind
+            "cert-manager.io/common-name"               = var.gitlab_config.hostname
+            "cert-manager.io/subject-alternative-names" = join(",", var.gitlab_config.dns_sans)
+            "cert-manager.io/duration"                  = var.certificate_config.duration
+            "cert-manager.io/renew-before"              = var.certificate_config.renew_before
           }
           tls = {
             enabled    = true

--- a/terraform/modules/kubernetes-addons/helm-chart-gitlab/variables.tf
+++ b/terraform/modules/kubernetes-addons/helm-chart-gitlab/variables.tf
@@ -15,6 +15,7 @@ variable "gitlab_config" {
   type = object({
     hostname = string
     edition  = string
+    dns_sans = list(string)
   })
 }
 

--- a/terraform/modules/kubernetes-addons/helm-chart-harbor/helm-chart-official.tf
+++ b/terraform/modules/kubernetes-addons/helm-chart-harbor/helm-chart-official.tf
@@ -36,6 +36,8 @@ resource "helm_release" "harbor" {
             "nginx.ingress.kubernetes.io/proxy-body-size" = "0"
             "cert-manager.io/issuer"                      = var.ingress_config.issuer_name
             "cert-manager.io/issuer-kind"                 = var.ingress_config.issuer_kind
+            "cert-manager.io/common-name"                 = var.harbor_config.hostname
+            "cert-manager.io/subject-alternative-names"   = join(",", var.harbor_config.dns_sans)
             "cert-manager.io/duration"                    = var.certificate_config.duration
             "cert-manager.io/renew-before"                = var.certificate_config.renew_before
           }

--- a/terraform/modules/kubernetes-addons/helm-chart-harbor/variables.tf
+++ b/terraform/modules/kubernetes-addons/helm-chart-harbor/variables.tf
@@ -17,6 +17,7 @@ variable "harbor_config" {
     notary_prefix  = string
     admin_password = string
     secret_key     = string # for internal encryption (core-secret)
+    dns_sans       = list(string)
   })
 }
 


### PR DESCRIPTION

## Summary

This PR addresses three critical core issues causing K8s certificate chain failures: domain stripping caused by Vault policies, incomplete Common Names (CN) due to missing CSR metadata, and domain overwriting resulting from multiple Ingress resource contention. Additionally, it completes the metadata-driven refactoring from L00 through L50.

<img width="1920" height="1055" alt="Screenshot  20260423-194526" src="https://github.com/user-attachments/assets/91f8f5f9-703b-4ddc-8c2e-0400f8d4742b" />

## Changes

### Core Architecture

1. **L00 Metadata Injection**: Introduced verification path configurations into `global_pki_map` to eliminate hardcoded identity identification.
2. **L20/L25 Authentication**: Implemented metadata-driven Vault authentication and policy generation.

### Fixes & Technical Debt

- **Vault Domain Stripping (L25)**:
    - *Problem*: `allowed_domains` was restricted to exact FQDNs, causing the Vault signing engine to **forcefully strip SAN domain fields** (Harbor) or error out (GitLab), which was the root cause of certificate/domain mismatches.
    - *Solution*: Federated the root domain to permit all subdomains.
- **Incomplete Certificate Subject (L25/L50)**:
    - *Problem*: CSR subjects generated by `cert-manager` were empty, resulting in Vault certificates **completely lacking a CN**, preventing the establishment of a valid certificate identity.
    - *Solution*: Enabled `require_cn` in Vault and explicitly mandated `common-name` population within Ingress annotations.
- **Domain Overwrite Contention (L50 GitLab)**:
    - *Problem*: Multiple Ingresses (Webservice/KAS) competed for the same Secret, causing `cert-manager` to only issue the certificate for the last updated domain (e.g., only `kas`), invalidating the primary domain certificate.
    - *Solution*: Utilized `subject-alternative-names` annotations to force the consolidation of all required domains.

### Refactoring

- **SSoT Alignment (L50)**: Removed internal string manipulation logic within modules in favor of externally injected `dns_san` lists to ensure consistency.

### Verification

- [x] **Certificate Integrity**: Confirmed certificates contain both CN and a complete SAN list.
- [x] **VIP Communication**: Verified that nodes can complete certificate requests via the VIP.
- [x] **Idempotency**: Verified no unexpected changes during repeated Apply executions.