### PR TITLE
feat(harbor-oci): Automate Helm Sync via Replication Policy with Charts Pre-Pull

### DIFF
--- a/README-zh-TW.md
+++ b/README-zh-TW.md
@@ -539,13 +539,14 @@ git clone --depth 1 https://github.com/csning1998-old/on-premise-gitlab-deployme
 
     或者如 B.1-2 所述使用容器，較為簡便
 
-6.  由於 Layer 50 相關的 Helm Chart 一律都採用 OCI 與 Bootstrapper Harbor 進行連線，因此需要先從遠端 `helm pull` 相關 Artifacts 並且推送到 Bootstrapper Harbor 中。要先確保 `30-infra-harbor-bootstrapper-frontend` 與 `40-provision-harbor-bootstrapper-frontend` 都有成功執行
+6.  **更新**：以下內容已經整合在 `40-provision-harbor-bootstrapper-frontend` 中透過 Ansible Provider 驅動，可以直接執行 `terraform apply` 完成本項目內容
+
+    由於 Layer 50 相關的 Helm Chart 一律都採用 OCI 與 Bootstrapper Harbor 進行連線，因此需要先從遠端 `helm pull` 相關 Artifacts 並且推送到 Bootstrapper Harbor 中。要先確保 `30-infra-harbor-bootstrapper-frontend` 與 `40-provision-harbor-bootstrapper-frontend` 都有成功執行
 
     在確定 L30 與 L40 有關 Bootstrapper Harbor 已執行之後，可以直接執行以下指令（這之後會整合為透過 Ansible Provider 驅動）：
     1. **環境變數相關以及登入**
 
         ```bash
-        # 1. Environments
         export VAULT_ADDR="https://172.16.136.250:443"
         export VAULT_SKIP_VERIFY=true
 

--- a/README.md
+++ b/README.md
@@ -539,13 +539,14 @@ Successful execution and the display of virtual machines—regardless of whether
 
     Alternatively, containerized approach described in B.1-2 is more streamlined.
 
-6. Since Helm Charts related to Layer 50 consistently utilize OCI to connect with Bootstrapper Harbor, it is necessary to first `helm pull` the relevant artifacts from remote repositories and push them to Bootstrapper Harbor. Ensure that `30-infra-harbor-bootstrapper-frontend` and `40-provision-harbor-bootstrapper-frontend` have been executed successfully.
+6. **UPDATE**: The following has been integrated into `40-provision-harbor-bootstrapper-frontend` via the Ansible Provider. Executing `terraform apply` automates the requirements described below.
+
+    Since Helm Charts related to Layer 50 consistently utilize OCI to connect with Bootstrapper Harbor, it is necessary to first `helm pull` the relevant artifacts from remote repositories and push them to Bootstrapper Harbor. Ensure that `30-infra-harbor-bootstrapper-frontend` and `40-provision-harbor-bootstrapper-frontend` have been executed successfully.
 
     Once it is confirmed that the Bootstrapper Harbor related L30 and L40 have been executed, you can directly run the following commands (This will be integrated into L40 triggered by Ansible Provider):
     1. **Environment Variables and Login**
 
         ```bash
-        # 1. Environments
         export VAULT_ADDR="https://172.16.136.250:443"
         export VAULT_SKIP_VERIFY=true
 

--- a/ansible/playbooks/30-playbook-frontend.yaml
+++ b/ansible/playbooks/30-playbook-frontend.yaml
@@ -9,11 +9,11 @@
         key: "{{ node_role }}"
 
 # 1. Harbor Bootstrapper Registry
-- name: "Play [Harbor]: Configure Harbor Bootstrapper Cluster"
-  hosts: "{{ 'harbor_bootstrapper' if 'harbor_bootstrapper' in groups else [] }}"
-  become: true
-  roles:
-    - 30-bstrap-harbor
+# - name: "Play [Harbor]: Configure Harbor Bootstrapper Cluster"
+#   hosts: "{{ 'harbor_bootstrapper' if 'harbor_bootstrapper' in groups else [] }}"
+#   become: true
+#   roles:
+#     - 30-bstrap-harbor
 
 # 2. MicroK8s Cluster
 - name: "Play [Kubernetes]: Provision and Configure MicroK8s Cluster"

--- a/ansible/playbooks/30-playbook-frontend.yaml
+++ b/ansible/playbooks/30-playbook-frontend.yaml
@@ -9,11 +9,11 @@
         key: "{{ node_role }}"
 
 # 1. Harbor Bootstrapper Registry
-# - name: "Play [Harbor]: Configure Harbor Bootstrapper Cluster"
-#   hosts: "{{ 'harbor_bootstrapper' if 'harbor_bootstrapper' in groups else [] }}"
-#   become: true
-#   roles:
-#     - 30-bstrap-harbor
+- name: "Play [Harbor]: Configure Harbor Bootstrapper Cluster"
+  hosts: "{{ 'harbor_bootstrapper' if 'harbor_bootstrapper' in groups else [] }}"
+  become: true
+  roles:
+    - 30-bstrap-harbor
 
 # 2. MicroK8s Cluster
 - name: "Play [Kubernetes]: Provision and Configure MicroK8s Cluster"

--- a/ansible/playbooks/40-playbook-provision.yaml
+++ b/ansible/playbooks/40-playbook-provision.yaml
@@ -1,0 +1,7 @@
+---
+- name: Harbor OCI Chart Synchronization
+  hosts: "{{ 'harbor_bootstrapper_oci' if 'harbor_bootstrapper_oci' in groups else [] }}"
+  gather_facts: false
+  become: true
+  roles:
+    - role: 40-harbor-provision

--- a/ansible/roles/30-bstrap-harbor/defaults/main.yaml
+++ b/ansible/roles/30-bstrap-harbor/defaults/main.yaml
@@ -3,6 +3,10 @@
 harbor_install_dir: "/opt/harbor-install"
 harbor_data_dir: "/data/harbor"
 
+# Harbor Container User IDs (Harbor 2.x uses 10000)
+harbor_uid: 10000
+harbor_gid: 10000
+
 # PKI Paths (Host Side)
 # Vault Agent will write certs here.
 # Harbor will mount these files into the container.

--- a/ansible/roles/30-bstrap-harbor/tasks/B-configure.yaml
+++ b/ansible/roles/30-bstrap-harbor/tasks/B-configure.yaml
@@ -43,5 +43,5 @@
 
 - name: "B7. Set Harbor ID Facts"
   ansible.builtin.set_fact:
-    _harbor_uid: "{{ harbor_dir_stat.stat.uid | default(0) }}"
-    _harbor_gid: "{{ harbor_dir_stat.stat.gid | default(0) }}"
+    _harbor_uid: "{{ harbor_dir_stat.stat.uid | default(0) or harbor_uid }}"
+    _harbor_gid: "{{ harbor_dir_stat.stat.gid | default(0) or harbor_gid }}"

--- a/ansible/roles/30-bstrap-harbor/tasks/main.yaml
+++ b/ansible/roles/30-bstrap-harbor/tasks/main.yaml
@@ -30,6 +30,8 @@
     vault_agent_post_command: |
       cp {{ harbor_cert_path }} {{ harbor_config_cert_dir }}/server.crt
       cp {{ harbor_key_path }} {{ harbor_config_cert_dir }}/server.key
+      chown {{ _harbor_uid }}:{{ _harbor_gid }} {{ harbor_config_cert_dir }}/server.crt
+      chown {{ _harbor_uid }}:{{ _harbor_gid }} {{ harbor_config_cert_dir }}/server.key
       chmod 0644 {{ harbor_config_cert_dir }}/server.crt
       chmod 0600 {{ harbor_config_cert_dir }}/server.key
       docker ps -q -f name=^nginx$ | grep -q . && docker exec -i nginx nginx -s reload || true

--- a/ansible/roles/30-redis/tasks/main.yaml
+++ b/ansible/roles/30-redis/tasks/main.yaml
@@ -23,7 +23,7 @@
     vault_agent_group: "{{ redis_group }}"
     vault_agent_cert_base_dir: "/etc/redis/certs"
     vault_agent_post_command: "systemctl restart redis-server redis-sentinel"
-    vault_agent_ip_sans: "{{ advertise_ip }}"
+    vault_agent_ip_sans: "{{ advertise_ip }},{{ redis_ha_virtual_ip }}"
 
 - name: "Section C. Manage Redis Services"
   ansible.builtin.include_tasks: C-service.yaml

--- a/ansible/roles/40-harbor-provision/defaults/main.yaml
+++ b/ansible/roles/40-harbor-provision/defaults/main.yaml
@@ -1,0 +1,50 @@
+---
+# Harbor Configuration
+harbor_registry: "harbor-bootstrapper.production.iac.local"
+harbor_project: "helm-charts"
+harbor_robot_user: "robot$helm-charts+helm-pusher"
+
+# Vault Configuration (Inherited from extra_vars but defaulted here for safety)
+vault_addr: "https://172.16.136.250:8200"
+
+# List of Helm Charts to Synchronize
+helm_charts_to_sync:
+  - name: "ingress-nginx"
+    version: "4.10.0"
+    repo: "https://kubernetes.github.io/ingress-nginx"
+    is_oci: false
+
+  - name: "ingress-nginx"
+    version: "4.13.1"
+    repo: "https://kubernetes.github.io/ingress-nginx"
+    is_oci: false
+
+  - name: "metrics-server"
+    version: "3.13.0"
+    repo: "https://kubernetes-sigs.github.io/metrics-server/"
+    is_oci: false
+
+  - name: "cert-manager"
+    version: "v1.14.0"
+    repo: "oci://quay.io/jetstack/charts"
+    is_oci: true
+
+  - name: "local-path-provisioner"
+    version: "0.0.35"
+    repo: "oci://ghcr.io/rancher/local-path-provisioner/charts"
+    is_oci: true
+
+  - name: "gitlab"
+    version: "9.8.2"
+    repo: "https://charts.gitlab.io/"
+    is_oci: false
+
+  - name: "tigera-operator"
+    version: "v3.28.0"
+    repo: "https://docs.tigera.io/calico/charts"
+    is_oci: false
+
+  - name: "harbor"
+    version: "1.18.0"
+    repo: "https://helm.goharbor.io"
+    is_oci: false

--- a/ansible/roles/40-harbor-provision/defaults/main.yaml
+++ b/ansible/roles/40-harbor-provision/defaults/main.yaml
@@ -1,14 +1,5 @@
 ---
-# Harbor Configuration
-harbor_registry: "harbor-bootstrapper.production.iac.local"
-harbor_project: "helm-charts"
-harbor_robot_user: "robot$helm-charts+helm-pusher"
-
-# Vault Configuration (Inherited from extra_vars but defaulted here for safety)
-vault_addr: "https://172.16.136.250:8200"
-
-# List of Helm Charts to Synchronize
-helm_charts_to_sync:
+helm_charts_to_sync: # List of Helm Charts to Synchronize
   - name: "ingress-nginx"
     version: "4.10.0"
     repo: "https://kubernetes.github.io/ingress-nginx"

--- a/ansible/roles/40-harbor-provision/tasks/main.yml
+++ b/ansible/roles/40-harbor-provision/tasks/main.yml
@@ -6,7 +6,7 @@
     role_id: "{{ vault_approle_role_id }}"
     secret_id: "{{ vault_approle_secret_id }}"
   register: vault_auth
-  # no_log: true
+  no_log: true
 
 - name: Step 2. Retrieve Harbor Robot credentials from Vault (Standard KV2)
   community.hashi_vault.vault_kv2_get:
@@ -17,7 +17,7 @@
     role_id: "{{ vault_approle_role_id }}"
     secret_id: "{{ vault_approle_secret_id }}"
   register: harbor_creds
-  # no_log: true
+  no_log: true
 
 - name: Step 3. Force local DNS resolution for Harbor FQDN
   ansible.builtin.lineinfile:

--- a/ansible/roles/40-harbor-provision/tasks/main.yml
+++ b/ansible/roles/40-harbor-provision/tasks/main.yml
@@ -1,0 +1,66 @@
+---
+- name: Step 1. Authenticate with Vault via AppRole
+  community.hashi_vault.vault_login:
+    url: "{{ vault_addr }}"
+    auth_method: approle
+    role_id: "{{ vault_approle_role_id }}"
+    secret_id: "{{ vault_approle_secret_id }}"
+  register: vault_auth
+  # no_log: true
+
+- name: Step 2. Retrieve Harbor Robot credentials from Vault (Standard KV2)
+  community.hashi_vault.vault_kv2_get:
+    url: "{{ vault_addr }}"
+    engine_mount_point: "secret"
+    auth_method: "approle"
+    path: "on-premise-gitlab-deployment/harbor-bootstrapper/robot"
+    role_id: "{{ vault_approle_role_id }}"
+    secret_id: "{{ vault_approle_secret_id }}"
+  register: harbor_creds
+  # no_log: true
+
+- name: Step 3. Force local DNS resolution for Harbor FQDN
+  ansible.builtin.lineinfile:
+    path: /etc/hosts
+    line: "127.0.0.1 {{ harbor_registry }}"
+    state: present
+  become: true
+
+- name: Step 4. Verify Harbor OCI Login
+  kubernetes.core.helm_registry_auth:
+    host: "{{ harbor_registry }}"
+    username: "{{ harbor_robot_user }}"
+    password: "{{ harbor_creds.secret.password_pusher }}"
+  register: harbor_login
+
+- name: Step 5. Synchronize Helm Charts (Pull and Push)
+  ansible.builtin.shell: |
+    set -eo pipefail
+
+    {% set is_oci_chart = item.is_oci | default(false) | bool %}
+
+    {% if is_oci_chart %}
+    helm pull {{ item.repo }}/{{ item.name }} --version {{ item.version }}
+    {% else %}
+    helm pull {{ item.name }} --version {{ item.version }} --repo {{ item.repo }}
+    {% endif %}
+
+    CHART_FILE_CLEAN="{{ item.name }}-{{ item.version | regex_replace('^v', '') }}.tgz"
+    CHART_FILE_RAW="{{ item.name }}-{{ item.version }}.tgz"
+
+    if [ -f "$CHART_FILE_CLEAN" ]; then
+        TARGET_FILE="$CHART_FILE_CLEAN"
+    elif [ -f "$CHART_FILE_RAW" ]; then
+        TARGET_FILE="$CHART_FILE_RAW"
+    else
+        echo "Error: Chart file not found for {{ item.name }}" >&2
+        exit 1
+    fi
+
+    helm push "$TARGET_FILE" oci://{{ harbor_registry }}/{{ harbor_project }}
+    rm -f "$TARGET_FILE"
+  args:
+    executable: /bin/bash
+  loop: "{{ helm_charts_to_sync }}"
+  register: sync_results
+  changed_when: "'Pushed' in sync_results.stdout"

--- a/ansible/roles/40-harbor-provision/tasks/main.yml
+++ b/ansible/roles/40-harbor-provision/tasks/main.yml
@@ -22,6 +22,7 @@
 - name: Step 3. Force local DNS resolution for Harbor FQDN
   ansible.builtin.lineinfile:
     path: /etc/hosts
+    regexp: '^.*\\s+{{ harbor_registry | regex_escape }}$'
     line: "127.0.0.1 {{ harbor_registry }}"
     state: present
   become: true
@@ -36,31 +37,21 @@
 - name: Step 5. Synchronize Helm Charts (Pull and Push)
   ansible.builtin.shell: |
     set -eo pipefail
+    WORK_DIR=$(mktemp -d)
+    trap 'rm -rf "$WORK_DIR"' EXIT
+    cd "$WORK_DIR"
 
-    {% set is_oci_chart = item.is_oci | default(false) | bool %}
+    {% set is_oci = item.is_oci | default(false) | bool %}
 
-    {% if is_oci_chart %}
+    {% if is_oci %}
     helm pull {{ item.repo }}/{{ item.name }} --version {{ item.version }}
     {% else %}
     helm pull {{ item.name }} --version {{ item.version }} --repo {{ item.repo }}
     {% endif %}
 
-    CHART_FILE_CLEAN="{{ item.name }}-{{ item.version | regex_replace('^v', '') }}.tgz"
-    CHART_FILE_RAW="{{ item.name }}-{{ item.version }}.tgz"
-
-    if [ -f "$CHART_FILE_CLEAN" ]; then
-        TARGET_FILE="$CHART_FILE_CLEAN"
-    elif [ -f "$CHART_FILE_RAW" ]; then
-        TARGET_FILE="$CHART_FILE_RAW"
-    else
-        echo "Error: Chart file not found for {{ item.name }}" >&2
-        exit 1
-    fi
-
-    helm push "$TARGET_FILE" oci://{{ harbor_registry }}/{{ harbor_project }}
-    rm -f "$TARGET_FILE"
+    helm push *.tgz oci://{{ harbor_registry }}/{{ harbor_project }}
   args:
     executable: /bin/bash
   loop: "{{ helm_charts_to_sync }}"
   register: sync_results
-  changed_when: "'Pushed' in sync_results.stdout"
+  changed_when: "'Pushed' in (stderr | default(''))"

--- a/terraform/layers/30-infra-gitlab-frontend/locals.tf
+++ b/terraform/layers/30-infra-gitlab-frontend/locals.tf
@@ -133,8 +133,8 @@ locals {
     # Host Overrides
     node_extra_hosts = [
       {
-        host = local.state.metadata.global_pki_map["harbor-frontend"].dns_san[0]
-        ip   = local.state.network.infrastructure_map["core-harbor-frontend"].lb_config.vip
+        host = local.state.metadata.global_pki_map["harbor-bootstrapper-frontend"].dns_san[0]
+        ip   = local.state.network.infrastructure_map["core-harbor-bootstrapper-frontend"].lb_config.vip
       }
     ]
 

--- a/terraform/layers/30-infra-harbor-bootstrapper-frontend/output.tf
+++ b/terraform/layers/30-infra-harbor-bootstrapper-frontend/output.tf
@@ -1,4 +1,9 @@
 
+output "bstrap_harbor_fqdn" {
+  description = "The FQDN of the Bootstrap Harbor service."
+  value       = local.svc_fqdn
+}
+
 output "service_vip" {
   description = "The virtual IP assigned to the Bootstrap Harbor service from Central LB topology."
   value       = local.net_physical_infra.lb_config.vip

--- a/terraform/layers/30-infra-harbor-bootstrapper-frontend/output.tf
+++ b/terraform/layers/30-infra-harbor-bootstrapper-frontend/output.tf
@@ -30,3 +30,8 @@ output "ansible_inventory" {
   description = "The generated Ansible inventory content and file path."
   value       = module.bootstrap_harbor.ansible_inventory
 }
+
+output "ssh_config_file_path" {
+  description = "The path to the generated SSH configuration file."
+  value       = module.bootstrap_harbor.ssh_config_file_path
+}

--- a/terraform/layers/40-provision-harbor-bootstrapper-frontend/.terraform.lock.hcl
+++ b/terraform/layers/40-provision-harbor-bootstrapper-frontend/.terraform.lock.hcl
@@ -1,6 +1,28 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/ansible/ansible" {
+  version     = "1.4.0"
+  constraints = "~> 1.4.0"
+  hashes = [
+    "h1:B5hHbn7cL+yJ4xU7eTaqSsKL5jOtUBO7/vWoDcOTfuc=",
+    "zh:0d45166bf99e50a28a1221d17a13bf8fd461109e15675984768403f7c429fe09",
+    "zh:31cb7f7745f2d5ca88936ba3c86e408f242ed0754f4de02f85dc821cf8b46a3c",
+    "zh:3c9d29e378426a1f9926deb2aa71bcac27a50af46e0948896bfdcde5a9969e76",
+    "zh:3ff407b93aec8a9fae1aeb71214a1619ba06d28972ee514b403884ad88a994c9",
+    "zh:6149d11d87cff5ab3a55a490f95f9562845c910c74ae63f5722e753802d67ff6",
+    "zh:753edbf93b7112d868f55ac10a827ba581200d6aacf5355e4bf98ba07116a427",
+    "zh:90db772188e09afdaae43ff2a3d4c3a745203c8f0d63388b01ba6381ae4e0d07",
+    "zh:9966aa595937c426a4e114db91bb24d5f63184a9e0862195dc0a7bebfdfc7fc9",
+    "zh:a97fba47457b919556def655d5bc33354fedd39933b31e4a236ef5cf99030298",
+    "zh:b20001789127619435f99be52c32ed834ac74f16e1a3dbed7267a12be5254148",
+    "zh:b545ef33e31403854c7b39846f966508ea6e77fe455d5735f801c842210623dd",
+    "zh:b99e7e64786a1b22ac0f5972079f0c2934e7f58a8afd7d021217ef439e0c46ea",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:ff46f8ee2cb0bb9615e64230702645500c96546ccf5338b161c5ddcfd713f81d",
+  ]
+}
+
 provider "registry.terraform.io/goharbor/harbor" {
   version     = "3.10.1"
   constraints = "3.10.1"
@@ -21,6 +43,26 @@ provider "registry.terraform.io/goharbor/harbor" {
     "zh:efbe96db59519fc4ac1df84af675576f066d0c3326d45c3c4a064385296bc730",
     "zh:f052c9969962d6619e3dabf07a668113cf70d6fc54ce02f6e471734a2f789ebc",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.8.0"
+  constraints = "~> 2.8.0"
+  hashes = [
+    "h1:KCuj8nPbNP/ofQrAoQIuQ3CP6k+ADpULvxr7dw2PrpM=",
+    "zh:05f18164beab4a84753e5fedf463771ee0c6eca8e90346b8766f1e1c186dec1e",
+    "zh:563a0702e3711e25ba8930120899b681378b50cbb957fd204b37745c7c9b5f40",
+    "zh:5b56ab2ed70ed92721febb4a070af0837f1084c44825c18e4b95f7efb1d45d26",
+    "zh:6cbedc09b67a5cdb9501ff1b18a315fa46a38e0530424cab1c7f4b3acc75f489",
+    "zh:71b3bd50f89fb385a42a436ba2ce2b8e00f9de53535ce956deff1477b0b117dc",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9d45ac0a00b85cabdd398b859349d17f124c598b6e6bf272f1bb01321ce708a8",
+    "zh:a453efe8641a8f31fe806b597bf2b34d7b78b971a8e3919061ea89d61fda7b8d",
+    "zh:ac692bacb8c3dca8b5b37e5383168aca1f87d3cd7b40615efd300defb76494f5",
+    "zh:bda9e90c8547d90c9c573206985c5675cc1406047605af037a5069942c3c5966",
+    "zh:c30a1967de040d00f5038086dd53cdbfb78cc05d1dbc75037410f011bf2a20d8",
+    "zh:c80bbd1c3f56b3c836d80cf93ac0e8809305c2642f0c98b54bf5d05d3b12718c",
   ]
 }
 

--- a/terraform/layers/40-provision-harbor-bootstrapper-frontend/data.tf
+++ b/terraform/layers/40-provision-harbor-bootstrapper-frontend/data.tf
@@ -27,8 +27,14 @@ data "terraform_remote_state" "harbor_bootstrapper" {
   }
 }
 
-
-data "vault_generic_secret" "harbor_bootstrapper" {
+data "vault_kv_secret_v2" "harbor_bootstrapper" {
   provider = vault.production
-  path     = "secret/on-premise-gitlab-deployment/harbor-bootstrapper/app"
+  mount    = "secret"
+  name     = "on-premise-gitlab-deployment/harbor-bootstrapper/app"
+}
+
+data "vault_kv_secret_v2" "guest_vm" {
+  provider = vault.production
+  mount    = "secret"
+  name     = "on-premise-gitlab-deployment/guest_vm"
 }

--- a/terraform/layers/40-provision-harbor-bootstrapper-frontend/locals.tf
+++ b/terraform/layers/40-provision-harbor-bootstrapper-frontend/locals.tf
@@ -9,34 +9,36 @@ locals {
   sys_vault_addr = "https://${local.state.vault_sys.service_vip}:443"
 }
 
-locals {
-  ansible_extra_vars = {
-    vault_addr      = local.sys_vault_addr
-    harbor_registry = "harbor-bootstrapper.production.iac.local" # Or dynamic if available
-  }
+# locals {
+#   ansible_extra_vars = {
+#     vault_addr              = local.sys_vault_addr
+#     harbor_registry         = "harbor-bootstrapper.production.iac.local"
+#     vault_approle_role_id   = data.terraform_remote_state.vault_prod_bootstrap.outputs.production_role_id
+#     vault_approle_secret_id = data.terraform_remote_state.vault_prod_bootstrap.outputs.production_secret_id
+#   }
 
-  ansible_config = {
-    root_path       = abspath("${path.root}/../../../ansible")
-    ssh_config_path = local.state.harbor_bootstrapper.ssh_config_file_path
-    inventory_file  = "inventory-provision-harbor-bootstrapper-frontend.yaml"
-  }
+#   ansible_config = {
+#     root_path       = abspath("${path.root}/../../../ansible")
+#     ssh_config_path = local.state.harbor_bootstrapper.ssh_config_file_path
+#     inventory_file  = "inventory-provision-harbor-bootstrapper-frontend.yaml"
+#   }
 
-  # Re-wrap Layer 30 inventory into a specific group for L40 business logic
-  inventory_data = {
-    all = {
-      children = {
-        harbor_bootstrapper_oci = {
-          hosts = local.state.harbor_bootstrapper.ansible_inventory.data.all.children.primary.hosts
-        }
-      }
-    }
-  }
+#   # Re-wrap Layer 30 inventory into a specific group for L40 business logic
+#   inventory_data = {
+#     all = {
+#       children = {
+#         harbor_bootstrapper_oci = {
+#           hosts = local.state.harbor_bootstrapper.ansible_inventory.data.all.children.primary.hosts
+#         }
+#       }
+#     }
+#   }
 
-  credentials_vm = {
-    username             = data.vault_kv_secret_v2.guest_vm.data["vm_username"]
-    ssh_private_key_path = data.vault_kv_secret_v2.guest_vm.data["ssh_private_key_path"]
-  }
-}
+#   credentials_vm = {
+#     username             = data.vault_kv_secret_v2.guest_vm.data["vm_username"]
+#     ssh_private_key_path = data.vault_kv_secret_v2.guest_vm.data["ssh_private_key_path"]
+#   }
+# }
 
 locals {
   proxy_oci = {

--- a/terraform/layers/40-provision-harbor-bootstrapper-frontend/locals.tf
+++ b/terraform/layers/40-provision-harbor-bootstrapper-frontend/locals.tf
@@ -11,8 +11,10 @@ locals {
 
 locals {
   ansible_extra_vars = {
+    harbor_robot_user       = harbor_robot_account.helm_pusher.full_name
+    harbor_registry         = local.state.harbor_bootstrapper.bstrap_harbor_fqdn
+    harbor_project          = local.proxy_oci["helm_charts"].name
     vault_addr              = local.sys_vault_addr
-    harbor_registry         = "harbor-bootstrapper.production.iac.local"
     vault_approle_role_id   = data.terraform_remote_state.vault_prod_bootstrap.outputs.production_role_id
     vault_approle_secret_id = data.terraform_remote_state.vault_prod_bootstrap.outputs.production_secret_id
   }
@@ -28,7 +30,11 @@ locals {
     all = {
       children = {
         harbor_bootstrapper_oci = {
-          hosts = local.state.harbor_bootstrapper.ansible_inventory.data.all.children.primary.hosts
+          hosts = {
+            for k, v in local.state.harbor_bootstrapper.ansible_inventory.data.all.children.primary.hosts : k => merge(v, {
+              node_role = "harbor_bootstrapper_oci"
+            })
+          }
         }
       }
     }

--- a/terraform/layers/40-provision-harbor-bootstrapper-frontend/locals.tf
+++ b/terraform/layers/40-provision-harbor-bootstrapper-frontend/locals.tf
@@ -21,7 +21,16 @@ locals {
     inventory_file  = "inventory-provision-harbor-bootstrapper-frontend.yaml"
   }
 
-  inventory_data = local.state.harbor_bootstrapper.ansible_inventory.data
+  # Re-wrap Layer 30 inventory into a specific group for L40 business logic
+  inventory_data = {
+    all = {
+      children = {
+        harbor_bootstrapper_oci = {
+          hosts = local.state.harbor_bootstrapper.ansible_inventory.data.all.children.primary.hosts
+        }
+      }
+    }
+  }
 
   credentials_vm = {
     username             = data.vault_kv_secret_v2.guest_vm.data["vm_username"]

--- a/terraform/layers/40-provision-harbor-bootstrapper-frontend/locals.tf
+++ b/terraform/layers/40-provision-harbor-bootstrapper-frontend/locals.tf
@@ -1,12 +1,32 @@
 
-# State Object
 locals {
   state = {
-    vault_pki = data.terraform_remote_state.vault_pki.outputs
-    vault_sys = data.terraform_remote_state.vault_sys.outputs
+    vault_pki           = data.terraform_remote_state.vault_pki.outputs
+    vault_sys           = data.terraform_remote_state.vault_sys.outputs
+    harbor_bootstrapper = data.terraform_remote_state.harbor_bootstrapper.outputs
   }
 
   sys_vault_addr = "https://${local.state.vault_sys.service_vip}:443"
+}
+
+locals {
+  ansible_extra_vars = {
+    vault_addr      = local.sys_vault_addr
+    harbor_registry = "harbor-bootstrapper.production.iac.local" # Or dynamic if available
+  }
+
+  ansible_config = {
+    root_path       = abspath("${path.root}/../../../ansible")
+    ssh_config_path = local.state.harbor_bootstrapper.ssh_config_file_path
+    inventory_file  = "inventory-provision-harbor-bootstrapper-frontend.yaml"
+  }
+
+  inventory_data = local.state.harbor_bootstrapper.ansible_inventory.data
+
+  credentials_vm = {
+    username             = data.vault_kv_secret_v2.guest_vm.data["vm_username"]
+    ssh_private_key_path = data.vault_kv_secret_v2.guest_vm.data["ssh_private_key_path"]
+  }
 }
 
 locals {

--- a/terraform/layers/40-provision-harbor-bootstrapper-frontend/locals.tf
+++ b/terraform/layers/40-provision-harbor-bootstrapper-frontend/locals.tf
@@ -9,36 +9,36 @@ locals {
   sys_vault_addr = "https://${local.state.vault_sys.service_vip}:443"
 }
 
-# locals {
-#   ansible_extra_vars = {
-#     vault_addr              = local.sys_vault_addr
-#     harbor_registry         = "harbor-bootstrapper.production.iac.local"
-#     vault_approle_role_id   = data.terraform_remote_state.vault_prod_bootstrap.outputs.production_role_id
-#     vault_approle_secret_id = data.terraform_remote_state.vault_prod_bootstrap.outputs.production_secret_id
-#   }
+locals {
+  ansible_extra_vars = {
+    vault_addr              = local.sys_vault_addr
+    harbor_registry         = "harbor-bootstrapper.production.iac.local"
+    vault_approle_role_id   = data.terraform_remote_state.vault_prod_bootstrap.outputs.production_role_id
+    vault_approle_secret_id = data.terraform_remote_state.vault_prod_bootstrap.outputs.production_secret_id
+  }
 
-#   ansible_config = {
-#     root_path       = abspath("${path.root}/../../../ansible")
-#     ssh_config_path = local.state.harbor_bootstrapper.ssh_config_file_path
-#     inventory_file  = "inventory-provision-harbor-bootstrapper-frontend.yaml"
-#   }
+  ansible_config = {
+    root_path       = abspath("${path.root}/../../../ansible")
+    ssh_config_path = local.state.harbor_bootstrapper.ssh_config_file_path
+    inventory_file  = "inventory-provision-harbor-bootstrapper-frontend.yaml"
+  }
 
-#   # Re-wrap Layer 30 inventory into a specific group for L40 business logic
-#   inventory_data = {
-#     all = {
-#       children = {
-#         harbor_bootstrapper_oci = {
-#           hosts = local.state.harbor_bootstrapper.ansible_inventory.data.all.children.primary.hosts
-#         }
-#       }
-#     }
-#   }
+  # Re-wrap Layer 30 inventory into a specific group for L40 business logic
+  inventory_data = {
+    all = {
+      children = {
+        harbor_bootstrapper_oci = {
+          hosts = local.state.harbor_bootstrapper.ansible_inventory.data.all.children.primary.hosts
+        }
+      }
+    }
+  }
 
-#   credentials_vm = {
-#     username             = data.vault_kv_secret_v2.guest_vm.data["vm_username"]
-#     ssh_private_key_path = data.vault_kv_secret_v2.guest_vm.data["ssh_private_key_path"]
-#   }
-# }
+  credentials_vm = {
+    username             = data.vault_kv_secret_v2.guest_vm.data["vm_username"]
+    ssh_private_key_path = data.vault_kv_secret_v2.guest_vm.data["ssh_private_key_path"]
+  }
+}
 
 locals {
   proxy_oci = {
@@ -79,6 +79,12 @@ locals {
       endpoint_url  = "https://gcr.io"
       provider_name = "docker-registry"
       project_name  = "gcr-proxy"
+    }
+    ghcr_io = {
+      registry_name = "ghcr.io"
+      endpoint_url  = "https://ghcr.io"
+      provider_name = "docker-registry"
+      project_name  = "ghcr-proxy"
     }
   }
 }

--- a/terraform/layers/40-provision-harbor-bootstrapper-frontend/locals_replication.tf
+++ b/terraform/layers/40-provision-harbor-bootstrapper-frontend/locals_replication.tf
@@ -1,0 +1,61 @@
+
+locals {
+  external_registries = {
+    registry_k8s_io = {
+      name          = "oci-registry-k8s-io"
+      endpoint_url  = "https://registry.k8s.io"
+      provider_name = "docker-registry"
+    }
+    gitlab_registry = {
+      name          = "oci-registry-gitlab"
+      endpoint_url  = "https://registry.gitlab.com"
+      provider_name = "gitlab"
+    }
+    quay_io = {
+      name          = "oci-quay-io"
+      endpoint_url  = "https://quay.io"
+      provider_name = "quay"
+    }
+    ghcr_io = {
+      name          = "oci-ghcr-io"
+      endpoint_url  = "https://ghcr.io"
+      provider_name = "github"
+    }
+    docker_hub = {
+      name          = "oci-docker-hub"
+      endpoint_url  = "https://registry-1.docker.io"
+      provider_name = "docker-hub"
+    }
+  }
+
+  replication_policies = {
+    ingress_nginx = {
+      registry_key  = "registry_k8s_io"
+      resource_name = "ingress-nginx/ingress-nginx"
+    }
+    metrics_server = {
+      registry_key  = "registry_k8s_io"
+      resource_name = "metrics-server/metrics-server"
+    }
+    gitlab = {
+      registry_key  = "gitlab_registry"
+      resource_name = "gitlab-org/charts/gitlab"
+    }
+    cert_manager = {
+      registry_key  = "quay_io"
+      resource_name = "jetstack/cert-manager"
+    }
+    tigera = {
+      registry_key  = "quay_io"
+      resource_name = "tigera/operator"
+    }
+    harbor = {
+      registry_key  = "docker_hub"
+      resource_name = "bitnamicharts/harbor"
+    }
+    local_path = {
+      registry_key  = "ghcr_io"
+      resource_name = "rancher/local-path-provisioner"
+    }
+  }
+}

--- a/terraform/layers/40-provision-harbor-bootstrapper-frontend/locals_replication.tf
+++ b/terraform/layers/40-provision-harbor-bootstrapper-frontend/locals_replication.tf
@@ -43,7 +43,7 @@ locals {
     }
     cert_manager = {
       registry_key  = "quay_io"
-      resource_name = "jetstack/cert-manager"
+      resource_name = "jetstack/charts/cert-manager"
     }
     tigera = {
       registry_key  = "quay_io"

--- a/terraform/layers/40-provision-harbor-bootstrapper-frontend/outputs.tf
+++ b/terraform/layers/40-provision-harbor-bootstrapper-frontend/outputs.tf
@@ -13,3 +13,11 @@ output "service_vip" {
   description = "The virtual IP assigned to the Bootstrap Harbor service from Central LB topology."
   value       = data.terraform_remote_state.harbor_bootstrapper.outputs.service_vip
 }
+
+output "harbor_registry_fqdn" {
+  value = local.state.harbor_bootstrapper.bstrap_harbor_fqdn
+}
+
+output "helm_pusher_robot_username" {
+  value = harbor_robot_account.helm_pusher.full_name
+}

--- a/terraform/layers/40-provision-harbor-bootstrapper-frontend/providers.tf
+++ b/terraform/layers/40-provision-harbor-bootstrapper-frontend/providers.tf
@@ -32,5 +32,5 @@ provider "vault" {
 provider "harbor" {
   url      = "https://${data.terraform_remote_state.harbor_bootstrapper.outputs.service_vip}"
   username = "admin"
-  password = data.vault_generic_secret.harbor_bootstrapper.data["harbor_bootstrapper_admin_password"]
+  password = data.vault_kv_secret_v2.harbor_bootstrapper.data["harbor_bootstrapper_admin_password"]
 }

--- a/terraform/layers/40-provision-harbor-bootstrapper-frontend/replication.tf
+++ b/terraform/layers/40-provision-harbor-bootstrapper-frontend/replication.tf
@@ -21,6 +21,5 @@ resource "harbor_replication" "charts" {
 
   # Cron schedule: every 12 hours to keep it automated but not noisy
   schedule = "0 0 0,12 * * *"
-
   override = true
 }

--- a/terraform/layers/40-provision-harbor-bootstrapper-frontend/replication.tf
+++ b/terraform/layers/40-provision-harbor-bootstrapper-frontend/replication.tf
@@ -12,12 +12,15 @@ resource "harbor_replication" "charts" {
   action      = "pull"
   registry_id = harbor_registry.external[each.value.registry_key].registry_id
 
-  dest_namespace = harbor_project.proxy_oci["helm_charts"].name
+  # Destination is the central helm-charts project
+  dest_namespace = "helm-charts"
 
   filters {
     name = each.value.resource_name
   }
 
-  schedule = "manual"
+  # Cron schedule: every 12 hours to keep it automated but not noisy
+  schedule = "0 0 0,12 * * *"
+
   override = true
 }

--- a/terraform/layers/40-provision-harbor-bootstrapper-frontend/replication.tf
+++ b/terraform/layers/40-provision-harbor-bootstrapper-frontend/replication.tf
@@ -1,0 +1,23 @@
+
+resource "harbor_registry" "external" {
+  for_each      = local.external_registries
+  name          = each.value.name
+  endpoint_url  = each.value.endpoint_url
+  provider_name = each.value.provider_name
+}
+
+resource "harbor_replication" "charts" {
+  for_each    = local.replication_policies
+  name        = "sync-${each.key}"
+  action      = "pull"
+  registry_id = harbor_registry.external[each.value.registry_key].registry_id
+
+  dest_namespace = harbor_project.proxy_oci["helm_charts"].name
+
+  filters {
+    name = each.value.resource_name
+  }
+
+  schedule = "manual"
+  override = true
+}

--- a/terraform/layers/40-provision-harbor-bootstrapper-frontend/resources.tf
+++ b/terraform/layers/40-provision-harbor-bootstrapper-frontend/resources.tf
@@ -71,7 +71,9 @@ module "ansible_sync_oci" {
 
   depends_on = [
     vault_kv_secret_v2.robot_helm_creds,
-    harbor_project.proxy_oci
+    harbor_project.proxy_oci,
+    harbor_project.proxy_projects,
+    harbor_registry.proxy_registries
   ]
 
   status_trigger = local.state.harbor_bootstrapper.topology_node

--- a/terraform/layers/40-provision-harbor-bootstrapper-frontend/resources.tf
+++ b/terraform/layers/40-provision-harbor-bootstrapper-frontend/resources.tf
@@ -65,3 +65,18 @@ resource "vault_kv_secret_v2" "robot_helm_creds" {
     password_pusher = harbor_robot_account.helm_pusher.secret
   })
 }
+
+module "ansible_sync_oci" {
+  source = "../../modules/cluster-provision/ansible-runner"
+
+  depends_on = [
+    vault_kv_secret_v2.robot_helm_creds,
+    harbor_project.proxy_oci
+  ]
+
+  status_trigger = local.state.harbor_bootstrapper.topology_node
+  ansible_config = local.ansible_config
+  inventory_data = local.inventory_data
+  credentials_vm = local.credentials_vm
+  extra_vars     = local.ansible_extra_vars
+}

--- a/terraform/layers/40-provision-harbor-bootstrapper-frontend/resources.tf
+++ b/terraform/layers/40-provision-harbor-bootstrapper-frontend/resources.tf
@@ -66,19 +66,19 @@ resource "vault_kv_secret_v2" "robot_helm_creds" {
   })
 }
 
-module "ansible_sync_oci" {
-  source = "../../modules/cluster-provision/ansible-runner"
-
-  depends_on = [
-    vault_kv_secret_v2.robot_helm_creds,
-    harbor_project.proxy_oci,
-    harbor_project.proxy_projects,
-    harbor_registry.proxy_registries
-  ]
-
-  status_trigger = local.state.harbor_bootstrapper.topology_node
-  ansible_config = local.ansible_config
-  inventory_data = local.inventory_data
-  credentials_vm = local.credentials_vm
-  extra_vars     = local.ansible_extra_vars
-}
+# module "ansible_sync_oci" {
+#   source = "../../modules/cluster-provision/ansible-runner"
+# 
+#   depends_on = [
+#     vault_kv_secret_v2.robot_helm_creds,
+#     harbor_project.proxy_oci,
+#     harbor_project.proxy_projects,
+#     harbor_registry.proxy_registries
+#   ]
+# 
+#   status_trigger = local.state.harbor_bootstrapper.topology_node
+#   ansible_config = local.ansible_config
+#   inventory_data = local.inventory_data
+#   credentials_vm = local.credentials_vm
+#   extra_vars     = local.ansible_extra_vars
+# }

--- a/terraform/layers/40-provision-harbor-bootstrapper-frontend/resources.tf
+++ b/terraform/layers/40-provision-harbor-bootstrapper-frontend/resources.tf
@@ -14,7 +14,6 @@ resource "harbor_project" "proxy_projects" {
   registry_id   = harbor_registry.proxy_registries[each.key].registry_id
 }
 
-
 resource "harbor_project" "proxy_oci" {
   for_each      = local.proxy_oci
   name          = each.value.name
@@ -24,14 +23,28 @@ resource "harbor_project" "proxy_oci" {
 
 resource "harbor_robot_account" "helm_puller" {
   name        = "helm-puller"
-  description = "Robot account for Helm Provider to pull charts"
-  level       = "project"
+  description = "System level Robot account for Helm Provider to pull from local and proxy caches"
+
+  level = "system"
+
   permissions {
     kind      = "project"
     namespace = harbor_project.proxy_oci["helm_charts"].name
     access {
       action   = "pull"
       resource = "repository"
+    }
+  }
+
+  dynamic "permissions" {
+    for_each = harbor_project.proxy_projects
+    content {
+      kind      = "project"
+      namespace = permissions.value.name
+      access {
+        action   = "pull"
+        resource = "repository"
+      }
     }
   }
 }
@@ -66,19 +79,19 @@ resource "vault_kv_secret_v2" "robot_helm_creds" {
   })
 }
 
-# module "ansible_sync_oci" {
-#   source = "../../modules/cluster-provision/ansible-runner"
-# 
-#   depends_on = [
-#     vault_kv_secret_v2.robot_helm_creds,
-#     harbor_project.proxy_oci,
-#     harbor_project.proxy_projects,
-#     harbor_registry.proxy_registries
-#   ]
-# 
-#   status_trigger = local.state.harbor_bootstrapper.topology_node
-#   ansible_config = local.ansible_config
-#   inventory_data = local.inventory_data
-#   credentials_vm = local.credentials_vm
-#   extra_vars     = local.ansible_extra_vars
-# }
+module "ansible_sync_oci" {
+  source = "../../modules/cluster-provision/ansible-runner"
+
+  depends_on = [
+    vault_kv_secret_v2.robot_helm_creds,
+    harbor_project.proxy_oci,
+    harbor_project.proxy_projects,
+    harbor_registry.proxy_registries
+  ]
+
+  status_trigger = local.state.harbor_bootstrapper.topology_node
+  ansible_config = local.ansible_config
+  inventory_data = local.inventory_data
+  credentials_vm = local.credentials_vm
+  extra_vars     = local.ansible_extra_vars
+}

--- a/terraform/middleware/ha-service-kvm-general/outputs.tf
+++ b/terraform/middleware/ha-service-kvm-general/outputs.tf
@@ -45,3 +45,8 @@ output "ansible_inventory" {
     file_path = module.ansible_runner.inventory_file_path
   }
 }
+
+output "ssh_config_file_path" {
+  description = "The path to the generated SSH configuration file."
+  value       = module.ssh_manager.ssh_config_file_path
+}

--- a/terraform/modules/cluster-provision/ansible-runner/main.tf
+++ b/terraform/modules/cluster-provision/ansible-runner/main.tf
@@ -21,6 +21,7 @@ locals {
     abspath("${path.module}/../../../../ansible/playbooks/10-playbook-shared.yaml"),
     abspath("${path.module}/../../../../ansible/playbooks/30-playbook-infra-statesful-sets.yaml"),
     abspath("${path.module}/../../../../ansible/playbooks/30-playbook-frontend.yaml"),
+    abspath("${path.module}/../../../../ansible/playbooks/40-playbook-provision.yaml"),
   ]
 }
 

--- a/terraform/modules/kubernetes-addons/helm-chart-gitlab/helm-chart-official.tf
+++ b/terraform/modules/kubernetes-addons/helm-chart-gitlab/helm-chart-official.tf
@@ -176,6 +176,9 @@ resource "helm_release" "gitlab" {
           image = var.image_registry != null ? {
             repository = "${var.image_registry.registry}/${var.image_registry.repository}/gitlab-webservice-${var.gitlab_config.edition}"
           } : null
+          workhorse = {
+            image = var.image_registry != null ? "${var.image_registry.registry}/${var.image_registry.repository}/gitlab-workhorse-${var.gitlab_config.edition}" : null
+          }
           deployment = {
             hostAliases = var.external_services.minio.ip != null ? [
               {


### PR DESCRIPTION
## Summary

This PR primarily automates the previously manual pre-pulling of Helm Charts via Ansible in `L40` Harbor Bootstrapper to facilitate `L50` operations. It implements Replication Policies for `L40` to enable event-driven synchronization (triggered upon image push) and support resumable transfers, addressing the issue where Harbor Proxy Cache does not support OCI Helm charts (Reference Issue [#19086](https://github.com/goharbor/harbor/issues/19086)).

Note: As there is only one on-prem Harbor instance and all Kubernetes nodes have direct access, this configuration may be reverted in the future.

## Changes

### Core Architecture

1. **Pre-pull Charts**: Implement Ansible Playbook to pull Helm Charts to Harbor prior to `L50`.
2. **Feature/Change B**: Add `workhorse` image configuration to the GitLab Helm Chart; this was previously omitted but is required by `webservice`.

### Fixes & Technical Debt

- **tf/kubeadm/registry**:
    - _Problem_: `node_extra_hosts` incorrectly pointed to `harbor-frontend` instead of bootstrapper harbor, preventing nodes from resolving the registry address.
    - _Solution_: Corrected `node_extra_hosts` to point to the valid bootstrapper harbor.
- **tf/gitlab-redis**:
    - _Problem_: Missing `redis_ha_virtual_ip` in the SAN list, preventing `gitlab-kas` from establishing encrypted connections.
    - _Solution_: Forcefully added Redis VIP to the SAN list.
- **harbor**:
    - _Problem_: Harbor Proxy Cache does not support OCI Helm charts (Issue [#19086](https://github.com/goharbor/harbor/issues/19086)).
    - _Solution_: Adopted explicit OCI Replication Policies and re-enabled Ansible synchronization modules.
- **ansible/harbor/nginx**:
    - _Problem_: SSL private key permissions were set to `600` and owned by `root`, making them unreadable by the Harbor Nginx container running as UID `10000`.
    - _Solution_: Configured certificate directory permissions and ownership to align with Harbor's default UID/GID (`10000`).

### Refactoring

- **bstrap-harbor/oci**: Refactored the variable transmission mechanism so that `defaults/main.yaml` only needs to declare Helm Charts, improving module versatility.
- **tf/harbor-oci**: Migrated Helm chart synchronization logic from Ansible to the `goharbor/harbor` Terraform provider's replication feature.

### Verification

- [x] **L40 Pre-pull**: `L40` Pre-pull images confirmed via GUI.
- [x] **L40 Replication**: `L40` Replication Policy functional as confirmed via GUI.
- [x] **VIP Access**: VIPs for Harbor, GitLab, and Harbor Bootstrapper are accessible.
- [x] **Idempotency**: Deployment state remains consistent upon repeated execution.
- [x] **Registry Artifacts**: `workhorse` image is present in the Harbor Registry.
