### PR TITLE
feat(central-lb): Stabilize Central Load Balancer Architecture and Optimize PKI Lifecycle

### DIFF
--- a/ansible/roles/10-load-balancer/templates/haproxy.cfg.j2
+++ b/ansible/roles/10-load-balancer/templates/haproxy.cfg.j2
@@ -44,38 +44,25 @@ listen stats
 # Service: {{ segment.name }}
 {% if segment.ports %}
 {% for port_name, port_cfg in segment.ports.items() %}
+{% set port_suffix = port_name | replace('-', '_') %}
+{% set backend_name = "be_" ~ (segment.name | replace('-', '_')) ~ "_" ~ port_suffix %}
 
-    # Frontend for {{ port_name }}
-frontend fe_{{ segment.name | replace('-', '_') }}_{{ port_name }}
-    {# TCP Passthrough for all services — TLS termination is the responsibility of each application #}
+frontend fe_{{ segment.name | replace('-', '_') }}_{{ port_suffix }}
     bind {{ segment.vip }}:{{ port_cfg.frontend }}
     mode tcp
     option tcplog
-    default_backend be_{{ segment.name | replace('-', '_') }}_{{ port_name }}
+    default_backend {{ backend_name }}
 
-# Backend for {{ port_name }} (Saturation Slots)
-backend be_{{ segment.name | replace('-', '_') }}_{{ port_name }}
+backend {{ backend_name }}
     mode tcp
     balance roundrobin
-
-    {# Dynamic Health Check Logic #}
     {% if port_cfg.health_check_type == 'http' %}
     option httpchk GET {{ port_cfg.health_check_http_path | default('/') }}
     http-check expect {{ port_cfg.health_check_http_expect | default('status 200') }}
-    {% else %}
-    option tcp-check
-    {% endif %}
-
+    {% endif %} 
     {% for server in segment.backend_servers %}
-    {# If Vault then TCP Passthrough (no ssl), else if Health Check then HTTPS (check-ssl) #}
-    {% if 'vault' in segment.name %}
-    server {{ server.name }} {{ server.ip }}:{{ port_cfg.backend }} check inter {{ haproxy_health_check_inter }} fall {{ haproxy_health_check_fall }} rise {{ haproxy_health_check_rise }} check-ssl verify none
-    {% else %}
-    server {{ server.name }} {{ server.ip }}:{{ port_cfg.backend }} check inter {{ haproxy_health_check_inter }} fall {{ haproxy_health_check_fall }} rise {{ haproxy_health_check_rise }}{{ ' check-ssl verify none' if port_cfg.health_check_ssl | default(false) else '' }}
-    {% endif %}
+    server {{ server.name }} {{ server.ip }}:{{ port_cfg.backend }} check{% if port_cfg.health_check_port %} port {{ port_cfg.health_check_port }}{% endif %} inter {{ haproxy_health_check_inter }} fall {{ haproxy_health_check_fall }} rise {{ haproxy_health_check_rise }}{% if port_cfg.health_check_ssl | default(false) or 'vault' in segment.name %} check-ssl verify none{% endif %} {% if port_cfg.send_proxy_v2 | default(false) %} send-proxy-v2{% endif %} 
     {% endfor %}
-
-    {# close port loop #}
 {% endfor %}
 {% endif %}
 {% endfor %}

--- a/ansible/roles/10-load-balancer/templates/keepalived.conf.j2
+++ b/ansible/roles/10-load-balancer/templates/keepalived.conf.j2
@@ -5,6 +5,21 @@ global_defs {
     script_user root
 }
 
+vrrp_script chk_haproxy {
+    script "/usr/bin/killall -0 haproxy"
+    interval 2
+    weight -20
+}
+
+{# Sync Group ensures all VIPs failover together #}
+vrrp_sync_group VG_ALL {
+    group {
+{% for segment in lb_service_segments %}
+        VI_{{ segment.name | upper | replace('-', '_') }}
+{% endfor %}
+    }
+}
+
 {# Iterate to generate VRRP Instance #}
 {% for segment in lb_service_segments %}
 vrrp_instance VI_{{ segment.name | upper | replace('-', '_') }} {
@@ -18,12 +33,14 @@ vrrp_instance VI_{{ segment.name | upper | replace('-', '_') }} {
     {# Priority setting: Master (First in lb group) = 100, Others = 90 #}
     priority {{ 100 if inventory_hostname == groups['load_balancer'][0] else 90 }}
     advert_int 1
+    nopreempt
 
-    unicast_src_ip {{ hostvars[inventory_hostname].ansible_host }}
+    {# Use specific segment IPs instead of the global ansible_host #}
+    unicast_src_ip {{ hostvars[inventory_hostname]['service_ips'][segment.name] }}
     unicast_peer {
 {% for host in groups['load_balancer'] %}
 {% if host != inventory_hostname %}
-        {{ hostvars[host].ansible_host }}
+        {{ hostvars[host]['service_ips'][segment.name] }}
 {% endif %}
 {% endfor %}
     }
@@ -35,6 +52,11 @@ vrrp_instance VI_{{ segment.name | upper | replace('-', '_') }} {
 
     virtual_ipaddress {
         {{ segment.vip }}
+    }
+
+    {# Bind HAProxy health state to VIP ownership #}
+    track_script {
+        chk_haproxy
     }
 }
 {% endfor %}

--- a/terraform/layers/00-foundation-metadata/terraform.tfvars.example
+++ b/terraform/layers/00-foundation-metadata/terraform.tfvars.example
@@ -170,6 +170,56 @@ service_catalog = {
           { name_suffix = "drive2", capacity_gib = 10 }
         ]
       }
+      # "gitaly" = {
+      #   provider   = "kvm"
+      #   runtime    = "baremetal"
+      #   cidr_index = 138
+      #   tags       = []
+      #   ip_range   = { start_ip = 200, end_ip = 202 }
+      #   ports = {
+      #     "grpc"    = { frontend_port = 8075, backend_port = 8075 }
+      #     "metrics" = { frontend_port = 9236, backend_port = 9236 }
+      #   }
+      #   data_disks = [
+      #     { name_suffix = "data", capacity_gib = 100 }
+      #   ]
+      # }
+      # "praefact" = {
+      #   provider   = "kvm"
+      #   runtime    = "baremetal"
+      #   cidr_index = 140
+      #   tags       = ["with-141-praefact-patroni"]
+      #   ip_range   = { start_ip = 200, end_ip = 202 }
+      #   ports = {
+      #     "proxy"   = { frontend_port = 2305, backend_port = 2305 }
+      #     "metrics" = { frontend_port = 9652, backend_port = 9652 }
+      #   }
+      # }
+      # "praefact-patroni" = {
+      #   provider   = "kvm"
+      #   runtime    = "baremetal"
+      #   cidr_index = 141
+      #   tags       = ["with-140-praefact"]
+      #   ip_range   = { start_ip = 200, end_ip = 202 }
+      #   ports = {
+      #     "rw-proxy" = { frontend_port = 5432, backend_port = 5432 }
+      #     "api"      = { frontend_port = 8008, backend_port = 8008 }
+      #     "etcd"     = { frontend_port = 2379, backend_port = 2379 }
+      #   }
+      #   data_disks = [{ name_suffix = "data", capacity_gib = 50 }]
+      # }
+      "runner" = {
+        provider   = "kvm"
+        runtime    = "microk8s"
+        cidr_index = 139
+        tags       = []
+        ip_range   = { start_ip = 200, end_ip = 202 }
+        ports = {
+          "metrics" = { frontend_port = 9252, backend_port = 9252 }
+          "session" = { frontend_port = 8093, backend_port = 8093 }
+        }
+        data_disks = [{ name_suffix = "data", capacity_gib = 50 }]
+      }
     }
   },
   "harbor-bootstrapper" = {

--- a/terraform/layers/00-foundation-metadata/variables.tf
+++ b/terraform/layers/00-foundation-metadata/variables.tf
@@ -84,6 +84,8 @@ variable "service_catalog" {
         health_check_http_path   = optional(string, "/")
         health_check_http_expect = optional(string, "status 200")
         health_check_ssl         = optional(bool, false)
+        health_check_port        = optional(number)
+        send_proxy_v2            = optional(bool, false)
       })), {})
       data_disks = optional(list(object({
         name_suffix  = string

--- a/terraform/layers/25-security-pki/locals.tf
+++ b/terraform/layers/25-security-pki/locals.tf
@@ -63,5 +63,8 @@ locals {
     "gitlab-frontend" = {
       "secret/data/on-premise-gitlab-deployment/infrastructure/kubeconfig/gitlab" = { capabilities = ["create", "update", "read"] }
     }
+    "gitlab-runner" = {
+      "secret/data/on-premise-gitlab-deployment/infrastructure/kubeconfig/gitlab-runner" = { capabilities = ["create", "update", "read"] }
+    }
   }
 }

--- a/terraform/layers/25-security-pki/outputs.tf
+++ b/terraform/layers/25-security-pki/outputs.tf
@@ -13,7 +13,7 @@ output "pki_configuration" {
     lease_durations = {
       default = format("%dh", var.vault_pki_engine_config.default_lease_ttl_seconds / 3600)
       max     = format("%dh", var.vault_pki_engine_config.max_lease_ttl_seconds / 3600)
-      agent   = var.environment == "production" ? "12h" : "5m"
+      agent   = var.environment == "production" ? "24h" : "12h"
     }
   }
 }

--- a/terraform/layers/30-infra-gitlab-frontend/data.tf
+++ b/terraform/layers/30-infra-gitlab-frontend/data.tf
@@ -55,11 +55,6 @@ data "terraform_remote_state" "harbor_proxy" {
   }
 }
 
-data "vault_generic_secret" "infrastructure" {
-  provider = vault.production
-  path     = "secret/on-premise-gitlab-deployment/infrastructure"
-}
-
 data "vault_generic_secret" "guest_vm" {
   provider = vault.production
   path     = "secret/on-premise-gitlab-deployment/guest_vm"

--- a/terraform/layers/30-infra-gitlab-runner/.terraform.lock.hcl
+++ b/terraform/layers/30-infra-gitlab-runner/.terraform.lock.hcl
@@ -1,0 +1,106 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/ansible/ansible" {
+  version     = "1.4.0"
+  constraints = "~> 1.4.0"
+  hashes = [
+    "h1:B5hHbn7cL+yJ4xU7eTaqSsKL5jOtUBO7/vWoDcOTfuc=",
+    "zh:0d45166bf99e50a28a1221d17a13bf8fd461109e15675984768403f7c429fe09",
+    "zh:31cb7f7745f2d5ca88936ba3c86e408f242ed0754f4de02f85dc821cf8b46a3c",
+    "zh:3c9d29e378426a1f9926deb2aa71bcac27a50af46e0948896bfdcde5a9969e76",
+    "zh:3ff407b93aec8a9fae1aeb71214a1619ba06d28972ee514b403884ad88a994c9",
+    "zh:6149d11d87cff5ab3a55a490f95f9562845c910c74ae63f5722e753802d67ff6",
+    "zh:753edbf93b7112d868f55ac10a827ba581200d6aacf5355e4bf98ba07116a427",
+    "zh:90db772188e09afdaae43ff2a3d4c3a745203c8f0d63388b01ba6381ae4e0d07",
+    "zh:9966aa595937c426a4e114db91bb24d5f63184a9e0862195dc0a7bebfdfc7fc9",
+    "zh:a97fba47457b919556def655d5bc33354fedd39933b31e4a236ef5cf99030298",
+    "zh:b20001789127619435f99be52c32ed834ac74f16e1a3dbed7267a12be5254148",
+    "zh:b545ef33e31403854c7b39846f966508ea6e77fe455d5735f801c842210623dd",
+    "zh:b99e7e64786a1b22ac0f5972079f0c2934e7f58a8afd7d021217ef439e0c46ea",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:ff46f8ee2cb0bb9615e64230702645500c96546ccf5338b161c5ddcfd713f81d",
+  ]
+}
+
+provider "registry.terraform.io/dmacvicar/libvirt" {
+  version     = "0.9.0"
+  constraints = "0.9.0"
+  hashes = [
+    "h1:YwoSgD2sGcxdfkeObd7Ef0T936drDAWkJvIywZEhwx4=",
+    "zh:094531095ad0ea1d860ee1db8bfeee3e9c4bf8c343db56ed9d88ad3578aa251f",
+    "zh:1001cad6c7fc117f64a4f7dafee68fea53dfd31d75bef8a46c4ef8506eae271b",
+    "zh:40f080239b57af3e3b960f6de6aff50ee87b7e67380f181fdd4d02cad569e92b",
+    "zh:4a3f82bf481fdac21243d1a6e86bd3515e8b7c385efb2a4ca6f67b07e3a96a33",
+    "zh:9310f5c783d5d6cb0b316439aee4eebac6de5e5777c77ad03fba9aaf3827ac88",
+    "zh:94a0b1e3ef300af7aa1a3fc07ec99b16ff1fae52dbcf5ce0b4a2d7c61b565618",
+    "zh:97f64a765f1767973b07e3cca764f7c883d5f90229a31132ed2ea1d49d8d923c",
+    "zh:a2c2879b8c821f473df1370a58fe46c5807d42d97b509672112867d793bd032a",
+    "zh:b0f345013672730ef92abbe459934f024afd36284b075d75e2efde947068566a",
+    "zh:c034420e4dee112aad1a61ed6c37a3208147861d8a6fc6ccd698ca491573d2cc",
+    "zh:dfd8a774c1cbaaf04d3ef5cb1249da91854b143783e8b425449891f04d3390b9",
+    "zh:f087963fac5ee886338da2ac5cc4fd3973434dac50c43c13c8b2c8c8af548f05",
+    "zh:f0c29253432068182dc486c0da2894d42403cb85f69869a9a79d7ce590e3347d",
+    "zh:f3613b7dec0e1a1b618141e6b174e16c41ef7fce37965223f0a5bfb1d7972a81",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.8.0"
+  constraints = "~> 2.8.0"
+  hashes = [
+    "h1:KCuj8nPbNP/ofQrAoQIuQ3CP6k+ADpULvxr7dw2PrpM=",
+    "zh:05f18164beab4a84753e5fedf463771ee0c6eca8e90346b8766f1e1c186dec1e",
+    "zh:563a0702e3711e25ba8930120899b681378b50cbb957fd204b37745c7c9b5f40",
+    "zh:5b56ab2ed70ed92721febb4a070af0837f1084c44825c18e4b95f7efb1d45d26",
+    "zh:6cbedc09b67a5cdb9501ff1b18a315fa46a38e0530424cab1c7f4b3acc75f489",
+    "zh:71b3bd50f89fb385a42a436ba2ce2b8e00f9de53535ce956deff1477b0b117dc",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9d45ac0a00b85cabdd398b859349d17f124c598b6e6bf272f1bb01321ce708a8",
+    "zh:a453efe8641a8f31fe806b597bf2b34d7b78b971a8e3919061ea89d61fda7b8d",
+    "zh:ac692bacb8c3dca8b5b37e5383168aca1f87d3cd7b40615efd300defb76494f5",
+    "zh:bda9e90c8547d90c9c573206985c5675cc1406047605af037a5069942c3c5966",
+    "zh:c30a1967de040d00f5038086dd53cdbfb78cc05d1dbc75037410f011bf2a20d8",
+    "zh:c80bbd1c3f56b3c836d80cf93ac0e8809305c2642f0c98b54bf5d05d3b12718c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.2.2"
+  constraints = "3.2.2"
+  hashes = [
+    "h1:zT1ZbegaAYHwQa+QwIFugArWikRJI9dqohj8xb0GY88=",
+    "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",
+    "zh:32b1aaa1c3013d33c245493f4a65465eab9436b454d250102729321a44c8ab9a",
+    "zh:38eff7e470acb48f66380a73a5c7cdd76cc9b9c9ba9a7249c7991488abe22fe3",
+    "zh:4c2f1faee67af104f5f9e711c4574ff4d298afaa8a420680b0cb55d7bbc65606",
+    "zh:544b33b757c0b954dbb87db83a5ad921edd61f02f1dc86c6186a5ea86465b546",
+    "zh:696cf785090e1e8cf1587499516b0494f47413b43cb99877ad97f5d0de3dc539",
+    "zh:6e301f34757b5d265ae44467d95306d61bef5e41930be1365f5a8dcf80f59452",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:913a929070c819e59e94bb37a2a253c228f83921136ff4a7aa1a178c7cce5422",
+    "zh:aa9015926cd152425dbf86d1abdbc74bfe0e1ba3d26b3db35051d7b9ca9f72ae",
+    "zh:bb04798b016e1e1d49bcc76d62c53b56c88c63d6f2dfe38821afef17c416a0e1",
+    "zh:c23084e1b23577de22603cff752e59128d83cfecc2e6819edadd8cf7a10af11e",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/vault" {
+  version     = "5.5.0"
+  constraints = "5.5.0"
+  hashes = [
+    "h1:L1pyXCClhJC/u9ye/HO1HDnjgODn5df8dp1BBFgrvUU=",
+    "zh:2e582d3804206c64b19c18afa95618cd5b041ed102b5fb62ca19c756d2930e70",
+    "zh:402c72251454905ef72e34bbd26af9144cff72ce3887a06ea2da95cc31a37d26",
+    "zh:552a5c521abd77015787030dbf55fc85b108f3c11fcd0f75d1b29175ff44c74d",
+    "zh:5a5e5743e25e72dd1bb20e72ecc7767ebc37b42c5608bc0f4bb6519488adff18",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7d59a0eb34594043656959b0cccb0cf79c973e2633e764e5e7f859ca515f81da",
+    "zh:86f74f759a1bf721db55b874b96eb2c5553aae12e56926724a398ef50631b43c",
+    "zh:c37d43b71b2d9352fefbed14bc32ab6c4bf607fdb3fe1a2fa7044630f94296e9",
+    "zh:c6fa4d9bf3e2f84ffef5e27782c2be6166a4eb6c068de586839198baf9428044",
+    "zh:c983cec46278cc28fc6449ef6a2013b5bc10821e10856056f0d4ae0f9830fd16",
+    "zh:e7ab6e63e95e820780462f1df122629733114f6196b5bef5a64efe019c25a3fe",
+    "zh:f1a9ecb68f71bcddb5bd1ec2716bac14d19f0931faa4a46d9270d89028271e69",
+  ]
+}

--- a/terraform/layers/30-infra-gitlab-runner/backend.tf
+++ b/terraform/layers/30-infra-gitlab-runner/backend.tf
@@ -1,0 +1,6 @@
+
+terraform {
+  backend "local" {
+    path = "terraform.tfstate"
+  }
+}

--- a/terraform/layers/30-infra-gitlab-runner/data.tf
+++ b/terraform/layers/30-infra-gitlab-runner/data.tf
@@ -1,0 +1,62 @@
+
+data "terraform_remote_state" "metadata" {
+  backend = "local"
+  config = {
+    path = "${path.root}/../00-foundation-metadata/terraform.tfstate"
+  }
+}
+
+data "terraform_remote_state" "volume" {
+  backend = "local"
+  config = {
+    path = "${path.root}/../05-foundation-volume/terraform.tfstate"
+  }
+}
+
+data "terraform_remote_state" "load_balancer" {
+  backend = "local"
+  config = {
+    path = "${path.root}/../10-shared-load-balancer-frontend/terraform.tfstate"
+  }
+}
+
+data "terraform_remote_state" "vault_sys" {
+  backend = "local"
+  config = {
+    path = "${path.root}/../15-shared-vault-frontend/terraform.tfstate"
+  }
+}
+
+data "terraform_remote_state" "vault_prod_bootstrap" {
+  backend = "local"
+  config = {
+    path = "${path.root}/../20-security-vault-approle/terraform.tfstate"
+  }
+}
+
+data "terraform_remote_state" "vault_pki" {
+  backend = "local"
+  config = {
+    path = "${path.root}/../25-security-pki/terraform.tfstate"
+  }
+}
+
+
+data "vault_generic_secret" "guest_vm" {
+  provider = vault.production
+  path     = "secret/on-premise-gitlab-deployment/guest_vm"
+}
+
+data "terraform_remote_state" "harbor_bootstrapper" {
+  backend = "local"
+  config = {
+    path = "${path.root}/../30-infra-harbor-bootstrapper-frontend/terraform.tfstate"
+  }
+}
+
+data "terraform_remote_state" "harbor_proxy" {
+  backend = "local"
+  config = {
+    path = "${path.root}/../40-provision-harbor-bootstrapper-frontend/terraform.tfstate"
+  }
+}

--- a/terraform/layers/30-infra-gitlab-runner/locals.tf
+++ b/terraform/layers/30-infra-gitlab-runner/locals.tf
@@ -1,0 +1,124 @@
+
+# State Object
+locals {
+  state = {
+    metadata        = data.terraform_remote_state.metadata.outputs
+    volume          = data.terraform_remote_state.volume.outputs
+    network         = data.terraform_remote_state.load_balancer.outputs
+    vault_sys       = data.terraform_remote_state.vault_sys.outputs
+    vault_pki       = data.terraform_remote_state.vault_pki.outputs
+    harbor_registry = data.terraform_remote_state.harbor_bootstrapper.outputs
+    harbor_proxy    = data.terraform_remote_state.harbor_proxy.outputs
+  }
+}
+
+# Service Context
+locals {
+  primary_role    = var.primary_role
+  segments_map    = local.state.metadata.global_topology_network["gitlab"]
+  primary_segment = local.segments_map["runner"]
+  p_net_config    = local.state.network.infrastructure_map["core-gitlab-runner"]
+
+  # Pure Identity SSoT from Layer 00 (GitLab Runner is the 'runner' component)
+  svc_identity = local.state.metadata.global_topology_identity["gitlab"]["runner"]
+  svc_fqdn     = local.state.metadata.global_pki_map["gitlab-runner"].dns_san[0]
+
+  # Align with Postgres/Redis: Dynamic identity map for module input
+  node_identities = {
+    "runner" = local.state.metadata.global_topology_identity["gitlab"]["runner"]
+  }
+}
+
+# Network Context
+locals {
+  net_service_vip = local.p_net_config.lb_config.vip
+  network_infrastructure_map = {
+    default = local.p_net_config
+  }
+}
+
+# Security & App Context
+locals {
+  sys_vault_addr = "https://${local.state.vault_sys.service_vip}:443"
+
+  # System Credentials (OS/SSH)
+  sec_system_creds = {
+    username             = data.vault_generic_secret.guest_vm.data["vm_username"]
+    password             = data.vault_generic_secret.guest_vm.data["vm_password"]
+    ssh_public_key_path  = data.vault_generic_secret.guest_vm.data["ssh_public_key_path"]
+    ssh_private_key_path = data.vault_generic_secret.guest_vm.data["ssh_private_key_path"]
+  }
+
+  # Vault Agent Identity Prep (GitLab Runner SANs)
+  sec_vault_identity_key = "gitlab-runner"
+
+  sec_vault_agent_identity = {
+    vault_address = local.sys_vault_addr
+    auth_path     = local.state.vault_pki.workload_identities_approle[local.sec_vault_identity_key].auth_path
+    role_id       = local.state.vault_pki.workload_identities_approle[local.sec_vault_identity_key].role_id
+    role_name     = local.state.vault_pki.pki_configuration.pki_roles[local.sec_vault_identity_key].name
+    ca_cert_b64   = local.state.vault_pki.bootstrap_ca.content
+    secret_id     = vault_approle_auth_backend_role_secret_id.microk8s_agent.secret_id
+    common_name   = local.svc_fqdn
+  }
+}
+
+# Topology Component Construction
+locals {
+  storage_pool_name = local.svc_identity.storage_pool_name
+
+  topology_cluster = {
+    cluster_name      = local.svc_identity.cluster_name
+    storage_pool_name = local.storage_pool_name
+    components        = var.service_config
+  }
+}
+
+# 5. Ansible Configuration (Dynamic Inventory)
+locals {
+  # Dependency discovery: Use the physical SSoT key for the Harbor registry.
+  registry_pki_key = local.state.harbor_registry.pki_key
+
+  ansible_template_vars = {
+    # Service Identifiers
+    service_identifier = local.svc_identity.cluster_name
+
+    # Networking & HA
+    microk8s_ingress_vip       = local.net_service_vip
+    microk8s_allowed_subnet    = local.p_net_config.network.hostonly.cidr
+    microk8s_nat_subnet_prefix = join(".", slice(split(".", local.p_net_config.network.nat.gateway), 0, 3))
+    metallb_ip_range           = "${local.net_service_vip}-${local.net_service_vip}"
+    global_mss                 = local.state.metadata.global_network_baseline.global_mss
+
+    # Cluster Topology
+    microk8s_cluster_ips = [
+      for node_suffix, node_data in var.service_config["runner"].nodes :
+      cidrhost(local.p_net_config.network.hostonly.cidr, node_data.ip_suffix)
+    ]
+
+    # Registry & Proxy Config
+    registry_host       = local.state.metadata.global_pki_map[local.registry_pki_key].dns_san[0]
+    registry_vip        = local.state.harbor_registry.service_vip
+    harbor_docker_proxy = local.state.harbor_proxy.proxy_caches["docker_hub"].project_name
+    harbor_quay_proxy   = local.state.harbor_proxy.proxy_caches["quay_io"].project_name
+    harbor_k8s_proxy    = local.state.harbor_proxy.proxy_caches["k8s_io"].project_name
+
+    # Host Overrides
+    node_extra_hosts = [
+      { host = local.svc_fqdn, ip = local.net_service_vip },
+      { host = local.state.metadata.global_pki_map[local.registry_pki_key].dns_san[0], ip = local.state.harbor_registry.service_vip }
+    ]
+  }
+
+  ansible_extra_vars = {
+    vault_ca_cert_b64       = local.sec_vault_agent_identity.ca_cert_b64
+    vault_agent_role_id     = local.sec_vault_agent_identity.role_id
+    vault_agent_secret_id   = local.sec_vault_agent_identity.secret_id
+    vault_addr              = local.sys_vault_addr
+    vault_role_name         = local.sec_vault_agent_identity.role_name
+    vault_auth_path         = local.sec_vault_agent_identity.auth_path
+    vault_agent_common_name = local.sec_vault_agent_identity.common_name
+    vault_agent_cert_ttl    = local.state.vault_pki.pki_configuration.lease_durations.agent
+    service_name            = "gitlab-runner"
+  }
+}

--- a/terraform/layers/30-infra-gitlab-runner/main.tf
+++ b/terraform/layers/30-infra-gitlab-runner/main.tf
@@ -1,0 +1,23 @@
+
+module "microk8s_runner" {
+  source = "../../middleware/ha-service-kvm-general"
+
+  # Core Identifier & Topology
+  svc_identity               = local.svc_identity
+  node_identities            = local.node_identities
+  topology_cluster           = local.topology_cluster
+  storage_infrastructure_map = local.state.volume.storage_infrastructure_map
+
+  # Network & Infrastructure
+  network_infrastructure_map = local.network_infrastructure_map
+
+  # System Credentials
+  credentials_system            = local.sec_system_creds
+  security_vault_agent_identity = local.sec_vault_agent_identity
+
+  # Generic Ansible Configuration
+  ansible_generic_config = {
+    template_vars = local.ansible_template_vars
+    extra_vars    = local.ansible_extra_vars
+  }
+}

--- a/terraform/layers/30-infra-gitlab-runner/output.tf
+++ b/terraform/layers/30-infra-gitlab-runner/output.tf
@@ -1,0 +1,15 @@
+
+output "runner_microk8s_ip_list" {
+  description = "List of MicroK8s node IPs for GitLab Runner"
+  value       = local.ansible_template_vars.microk8s_cluster_ips
+}
+
+output "runner_microk8s_virtual_ip" {
+  description = "MicroK8s virtual IP for GitLab Runner"
+  value       = local.ansible_template_vars.microk8s_ingress_vip
+}
+
+output "ansible_inventory" {
+  description = "The generated Ansible inventory content and file path."
+  value       = module.microk8s_runner.ansible_inventory
+}

--- a/terraform/layers/30-infra-gitlab-runner/providers.tf
+++ b/terraform/layers/30-infra-gitlab-runner/providers.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    vault = {
+      source  = "hashicorp/vault"
+      version = "5.5.0"
+    }
+  }
+}
+
+# Production Provider (Layer 10 Vault)
+provider "vault" {
+  alias        = "production"
+  address      = local.sys_vault_addr
+  ca_cert_file = local.state.vault_pki.bootstrap_ca.path
+
+  auth_login {
+    path = "auth/approle/login"
+    parameters = {
+      role_id   = data.terraform_remote_state.vault_prod_bootstrap.outputs.production_role_id
+      secret_id = data.terraform_remote_state.vault_prod_bootstrap.outputs.production_secret_id
+    }
+  }
+  skip_child_token = true
+}

--- a/terraform/layers/30-infra-gitlab-runner/resources.tf
+++ b/terraform/layers/30-infra-gitlab-runner/resources.tf
@@ -1,0 +1,13 @@
+
+# Call the Identity Module to generate AppRole & Secret ID
+resource "vault_approle_auth_backend_role_secret_id" "microk8s_agent" {
+  provider = vault.production
+  # Path: local.state.vault_pki -> workload_identities_approle -> gitlab-runner
+  backend   = local.state.vault_pki.workload_identities_approle[local.sec_vault_identity_key].auth_path
+  role_name = local.state.vault_pki.workload_identities_approle[local.sec_vault_identity_key].role_name
+
+  # Metadata for Vault Audit Log
+  metadata = jsonencode({
+    "source" = "terraform-layer-30-infra-gitlab-runner"
+  })
+}

--- a/terraform/layers/30-infra-gitlab-runner/terraform.tfvars.example
+++ b/terraform/layers/30-infra-gitlab-runner/terraform.tfvars.example
@@ -1,0 +1,16 @@
+
+service_catalog_name = "harbor"
+
+harbor_microk8s_config = {
+  "frontend" = {
+    role            = "microk8s"
+    network_tier    = "default"
+    base_image_path = "../../../packer/output/base-microk8s/ubuntu-24-base-microk8s.qcow2"
+    nodes = {
+      "00" = { ip_suffix = 200, vcpu = 4, ram_size = 4096 }
+      # Uncomment the following lines for HA setup, abide by node % 2 != 0.
+      # "01" = { ip_suffix = 201, vcpu = 4, ram_size = 4096 }
+      # "02" = { ip_suffix = 202, vcpu = 4, ram_size = 4096 }
+    }
+  }
+}

--- a/terraform/layers/30-infra-gitlab-runner/variables.tf
+++ b/terraform/layers/30-infra-gitlab-runner/variables.tf
@@ -1,0 +1,32 @@
+
+variable "vault_dev_addr" {
+  description = "The address of the Vault server"
+  type        = string
+  default     = "https://127.0.0.1:8200"
+}
+
+variable "primary_role" {
+  description = "The primary role for this layer (e.g. 'microk8s')."
+  type        = string
+}
+
+variable "target_clusters" {
+  description = "A map that matches roles to the cluster name defined in Layer 00."
+  type        = map(string)
+}
+
+variable "service_config" {
+  description = "Compute topology for GitLab Runner Microk8s cluster"
+  type = map(object({
+    role            = string
+    network_tier    = string
+    base_image_path = string
+
+    nodes = map(object({
+      ip_suffix            = number
+      vcpu                 = number
+      ram_size             = number
+      os_disk_capacity_gib = optional(number)
+    }))
+  }))
+}

--- a/terraform/middleware/ha-service-kvm-central-lb/locals.tf
+++ b/terraform/middleware/ha-service-kvm-central-lb/locals.tf
@@ -154,6 +154,8 @@ locals {
                   health_check_http_path   = p_val.health_check_http_path
                   health_check_http_expect = p_val.health_check_http_expect
                   health_check_ssl         = p_val.health_check_ssl
+                  health_check_port        = p_val.health_check_port
+                  send_proxy_v2            = p_val.send_proxy_v2
                 }
               }
               tags = seg.tags

--- a/terraform/middleware/ha-service-kvm-central-lb/variables.tf
+++ b/terraform/middleware/ha-service-kvm-central-lb/variables.tf
@@ -68,6 +68,8 @@ variable "network_service_segments" {
       health_check_http_path   = optional(string, "/")
       health_check_http_expect = optional(string, "")
       health_check_ssl         = optional(bool, false)
+      health_check_port        = optional(number)
+      send_proxy_v2            = optional(bool, false)
     })))
 
     backend_servers = optional(list(object({

--- a/terraform/modules/cluster-provision/hypervisor-kvm-lb/main.tf
+++ b/terraform/modules/cluster-provision/hypervisor-kvm-lb/main.tf
@@ -198,6 +198,7 @@ resource "libvirt_domain" "nodes" {
         type   = "network"
         source = { network = iface.network_name }
         mac    = iface.mac
+        model  = "virtio"
       }
     ]
 

--- a/terraform/modules/cluster-provision/hypervisor-kvm/main.tf
+++ b/terraform/modules/cluster-provision/hypervisor-kvm/main.tf
@@ -203,7 +203,8 @@ resource "libvirt_domain" "nodes" {
         source = {
           network = var.libvirt_infrastructure[each.value.network_tier].network.nat.name_network
         }
-        mac = local.nodes_config[each.key].nat_mac
+        mac   = local.nodes_config[each.key].nat_mac
+        model = "virtio"
       },
       # 2. HostOnly Interface
       {
@@ -211,7 +212,8 @@ resource "libvirt_domain" "nodes" {
         source = {
           network = var.libvirt_infrastructure[each.value.network_tier].network.hostonly.name_network
         }
-        mac = local.nodes_config[each.key].hostonly_mac
+        mac   = local.nodes_config[each.key].hostonly_mac
+        model = "virtio"
       }
     ]
 


### PR DESCRIPTION
## Summary

This update aims to resolve High Availability (HA) stability issues for the Central Load Balancer (`CLB`), backend source IP transparency issues to improve `HAProxy`/`Keepalived` configuration logic, and adjust `Vault PKI` TTL policies. It also addresses system connection failures caused by premature certificate expiration and infrastructure-wide network stalls under high load.

Regarding the issue between `virtio` and `rtl8139`, the crux of the matter is that even when the MTU is correctly configured and packet sizes strictly adhere to standards, ensuring they are not dropped by routers for being oversized, and packets are still sent out without ever receiving a response. While the symptoms are behaviorally identical to an MTU black hole, the actual trigger mechanism is a **hardware performance collapse**.

An investigation of the **Centralized LB** via `journalctl` revealed the error: `rcu: INFO: rcu_preempt self-detected stall on CPU`. This indicates that `ksoftirqd/1` occupied the CPU for an excessive duration. The point of failure was identified within the `cp_start_xmit` function, which belongs to the driver for the **Realtek 8139** virtual NIC (a legacy 10/100M physical card model originally released in the 1990s). At the time of the failure, the LB was attempting to send `SYN-ACK` packets to respond to a massive volume of connection requests. This caused the CPU to be 100% utilized by the NIC driver, resulting in a context switch overload. Consequently, the kernel was unable to perform basic scheduling tasks, ultimately leading to an **RCU Stall** and a system crash.

## Changes

### Core Architecture

1.  **Patroni-Aware HTTP Health Checks**: Integrated checks against port `8008` (`Patroni` API) in `HAProxy` to ensure stateful database (`PostgreSQL`) write traffic is accurately directed to the `Primary` node.
2.  **L4 Source IP Transparency (PROXY v2)**: Enabled `PROXY Protocol v2` support to ensure the load balancer passes the original client IP to the backend `Ingress`, resolving traffic traceability and security policy failure issues.
3.  **Atomic Failover & Split-Brain Prevention**: Refactored `Keepalived` `vrrp_sync_group` and segment-specific heartbeat mechanisms aligned with business network segments to ensure synchronized failover of all `VIP`s.
4.  **NIC Model Optimization (virtio)**: Transitioned all LB and backend nodes from legacy `rtl8139` to `virtio` network models to eliminate kernel `RCU stalls` during high-concurrency traffic (e.g., GitLab Image Pulls).

### Fixes & Technical Debt

- **PKI Certificate Expiration (Vault Agent lifecycle)**:
    - _Problem_: The original ternary conditional in non-production environments only issued certificates with a 5-minute validity, resulting in extremely short renewal windows and triggering TLS validation failures between `Redis` and `KAS`.
    - _Solution_: Increased certificate validity to `12h` (development) / `24h` (production) to mitigate race conditions caused by TLS expiration.
- **Infrastructure Network Stall (NIC Driver Bottleneck)**:
    - _Problem_: Under high network load (GitLab Helm deployments), the `8139cp` driver saturated CPU softirqs, leading to system-wide hangs and "network death".
    - _Solution_: Enforced `model = "virtio"` in all `libvirt_domain` resources and removed `lifecycle` overrides to enable the hardware transition.

### Refactoring

- **SSoT Schema Extension**: Extended `00-foundation-metadata` structure to include `health_check_port` and `send_proxy_v2` under `Terraform` declarative management.
- **High Availability Logic**: Added `nopreempt` logic to prevent unnecessary `VIP` oscillation when nodes rejoin after repair.

### Verification

- [x] **Cluster Status**: Verified `HAProxy Stats` page (`8404`) displays correct backend node status.
- [x] **Failover**: Simulated network interruption to verify atomic `VIP` switching triggered by the sync group.
- [x] **VIP Access**: Verified `GitLab KAS` resumed connecting to `Redis` via TLS (with extended certificate TTL).
- [x] **Performance Check**: Confirmed `virtio` driver successfully handles concurrent `Image Pull` requests from `Bstrap Harbor` without latency spikes.
- [x] **Idempotency**: Re-executed playbook to confirm no configuration drift.
