### PR TITLE
feat(kubelet/tls): Implement Kubelet Certificate Signing and Secure Metrics Server

### DIFF
--- a/ansible/roles/30-kubeadm/handlers/main.yaml
+++ b/ansible/roles/30-kubeadm/handlers/main.yaml
@@ -25,3 +25,8 @@
     name: haproxy
     state: restarted
   listen: "Restart haproxy on primary master"
+
+- name: Restart kubelet
+  ansible.builtin.systemd:
+    name: kubelet
+    state: restarted

--- a/ansible/roles/30-kubeadm/handlers/main.yaml
+++ b/ansible/roles/30-kubeadm/handlers/main.yaml
@@ -4,6 +4,11 @@
   ansible.builtin.command: update-ca-certificates
   changed_when: false
 
+- name: Restart journald
+  ansible.builtin.systemd:
+    name: systemd-journald
+    state: restarted
+
 - name: Restart containerd service
   ansible.builtin.systemd:
     name: containerd

--- a/ansible/roles/30-kubeadm/tasks/A-prerequisites.yaml
+++ b/ansible/roles/30-kubeadm/tasks/A-prerequisites.yaml
@@ -7,6 +7,8 @@
       loop: "{{ ansible_facts.interfaces }}"
       when:
         - item != 'lo'
+        - item not in ['vxlan.calico', 'calico', 'flannel.1', 'cni0', 'docker0']
+        - not item.startswith('veth')
         - ansible_facts[item]['ipv4'] is defined
         - not (ansible_facts[item]['ipv4']['address'].startswith(kubeadm_nat_subnet_prefix | default('10.0.2')))
       no_log: true

--- a/ansible/roles/30-kubeadm/tasks/C-kubeadm-init.yaml
+++ b/ansible/roles/30-kubeadm/tasks/C-kubeadm-init.yaml
@@ -75,7 +75,10 @@
 
 - name: "C10. Fail if kubeadm init did not create admin.conf"
   ansible.builtin.fail:
-    msg: "kubeadm init failed to create /etc/kubernetes/admin.conf. Check /tmp/kubeadm-init.log for details."
+    msg: >-
+      kubeadm init failed to create /etc/kubernetes/admin.conf.
+      STDOUT: {{ kubeadm_pri_result.stdout | default('N/A') }}
+      STDERR: {{ kubeadm_pri_result.stderr | default('N/A') }}
   when: not admin_conf_stat_post_init.stat.exists and kubeadm_pri_result is changed
 
 - name: "C11. Create .kube directory for the root user"

--- a/ansible/roles/30-kubeadm/tasks/C-kubeadm-init.yaml
+++ b/ansible/roles/30-kubeadm/tasks/C-kubeadm-init.yaml
@@ -4,36 +4,32 @@
     path: "/var/log/journal"
     state: directory
     mode: "0755"
+  notify: "Restart journald"
 
-- name: "C2. Restart systemd-journald to apply persistent storage"
-  ansible.builtin.systemd:
-    name: systemd-journald
-    state: restarted
-
-- name: "C3. Ensure kubelet service is enabled"
+- name: "C2. Ensure kubelet service is enabled"
   ansible.builtin.systemd:
     name: kubelet
     enabled: true
 
-- name: "C4. Ensure /etc/kubernetes directory exists"
+- name: "C3. Ensure /etc/kubernetes directory exists"
   ansible.builtin.file:
     path: "/etc/kubernetes"
     state: directory
     mode: "0755"
 
-- name: "C5. Create kubeadm config file from template"
+- name: "C4. Create kubeadm config file from template"
   ansible.builtin.template:
     src: kubeadm-config.yaml.j2
     dest: "/etc/kubernetes/kubeadm-config.yaml"
     mode: "0644"
   register: kubeadm_config_result
 
-- name: "C6. Check if admin.conf already exists"
+- name: "C5. Check if admin.conf already exists"
   ansible.builtin.stat:
     path: "/etc/kubernetes/admin.conf"
   register: admin_conf_stat
 
-- name: "C7. Check current cluster kubelet configuration"
+- name: "C6. Check current cluster kubelet configuration"
   ansible.builtin.command: >-
     kubectl get configmap -n kube-system kubelet-config -o yaml
   register: current_kubelet_cm
@@ -41,24 +37,24 @@
   failed_when: false
   when: admin_conf_stat.stat.exists
 
-- name: "C8. Update cluster configuration if needed (Day 2)"
+- name: "C7. Update cluster configuration if needed (Day 2)"
   when: >
     admin_conf_stat.stat.exists and
     (kubeadm_config_result.changed | default(false) or
     ('serverTLSBootstrap: true' not in (current_kubelet_cm.stdout | default(''))))
   block:
-    - name: "C8a. Force upload new kubelet configuration to cluster ConfigMap"
+    - name: "C7a. Force upload new kubelet configuration to cluster ConfigMap"
       ansible.builtin.command: >-
         kubeadm init phase upload-config kubelet --config /etc/kubernetes/kubeadm-config.yaml
       changed_when: true
 
-    - name: "C8b. Apply uploaded kubelet configuration to local node"
+    - name: "C7b. Apply uploaded kubelet configuration to local node"
       ansible.builtin.command: >-
         kubeadm upgrade node phase kubelet-config
       changed_when: true
       notify: "Restart kubelet"
 
-- name: "C9. Run kubeadm init command"
+- name: "C8. Run kubeadm init command"
   ansible.builtin.command: >-
     kubeadm init
     --config="/etc/kubernetes/kubeadm-config.yaml"
@@ -72,30 +68,30 @@
     - Restart haproxy on primary master
     - Restart kubelet
 
-- name: "C10. Verify that admin.conf was created"
+- name: "C9. Verify that admin.conf was created"
   ansible.builtin.stat:
     path: "/etc/kubernetes/admin.conf"
   register: admin_conf_stat_post_init
 
-- name: "C11. Fail if kubeadm init did not create admin.conf"
+- name: "C10. Fail if kubeadm init did not create admin.conf"
   ansible.builtin.fail:
     msg: "kubeadm init failed to create /etc/kubernetes/admin.conf. Check /tmp/kubeadm-init.log for details."
   when: not admin_conf_stat_post_init.stat.exists and kubeadm_pri_result is changed
 
-- name: "C12. Create .kube directory for the root user"
+- name: "C11. Create .kube directory for the root user"
   ansible.builtin.file:
     path: "/root/.kube"
     state: directory
     mode: "0755"
 
-- name: "C13. Copy admin.conf to root's kube config"
+- name: "C12. Copy admin.conf to root's kube config"
   ansible.builtin.copy:
     src: "/etc/kubernetes/admin.conf"
     dest: "/root/.kube/config"
     remote_src: true
     mode: "0600"
 
-- name: "C14. Create .kube directory for the SSH user"
+- name: "C13. Create .kube directory for the SSH user"
   ansible.builtin.file:
     path: "/home/{{ ansible_user }}/.kube"
     state: directory
@@ -103,7 +99,7 @@
     group: "{{ ansible_user }}"
     mode: "0755"
 
-- name: "C15. Copy admin.conf to user's kube config"
+- name: "C14. Copy admin.conf to user's kube config"
   ansible.builtin.copy:
     src: "/etc/kubernetes/admin.conf"
     dest: "/home/{{ ansible_user }}/.kube/config"
@@ -112,7 +108,7 @@
     group: "{{ ansible_user }}"
     mode: "0644"
 
-- name: "C16. Fetch admin.conf to a predictable local path"
+- name: "C15. Fetch admin.conf to a predictable local path"
   ansible.builtin.fetch:
     src: "/etc/kubernetes/admin.conf"
     dest: "{{ kubeadm_fetched_kubeconfig_path }}"

--- a/ansible/roles/30-kubeadm/tasks/C-kubeadm-init.yaml
+++ b/ansible/roles/30-kubeadm/tasks/C-kubeadm-init.yaml
@@ -26,49 +26,76 @@
     src: kubeadm-config.yaml.j2
     dest: "/etc/kubernetes/kubeadm-config.yaml"
     mode: "0644"
+  register: kubeadm_config_result
 
 - name: "C6. Check if admin.conf already exists"
   ansible.builtin.stat:
     path: "/etc/kubernetes/admin.conf"
   register: admin_conf_stat
 
-- name: "C7. Run kubeadm init command"
-  ansible.builtin.shell: >-
+- name: "C7. Check current cluster kubelet configuration"
+  ansible.builtin.command: >-
+    kubectl get configmap -n kube-system kubelet-config -o yaml
+  register: current_kubelet_cm
+  changed_when: false
+  failed_when: false
+  when: admin_conf_stat.stat.exists
+
+- name: "C8. Update cluster configuration if needed (Day 2)"
+  when: >
+    admin_conf_stat.stat.exists and
+    (kubeadm_config_result.changed | default(false) or
+    ('serverTLSBootstrap: true' not in (current_kubelet_cm.stdout | default(''))))
+  block:
+    - name: "C8a. Force upload new kubelet configuration to cluster ConfigMap"
+      ansible.builtin.command: >-
+        kubeadm init phase upload-config kubelet --config /etc/kubernetes/kubeadm-config.yaml
+      changed_when: true
+
+    - name: "C8b. Apply uploaded kubelet configuration to local node"
+      ansible.builtin.command: >-
+        kubeadm upgrade node phase kubelet-config
+      changed_when: true
+      notify: "Restart kubelet"
+
+- name: "C9. Run kubeadm init command"
+  ansible.builtin.command: >-
     kubeadm init
     --config="/etc/kubernetes/kubeadm-config.yaml"
     --upload-certs
     --ignore-preflight-errors=Port-6443
-    > /tmp/kubeadm-init.log 2>&1
   args:
     creates: "/etc/kubernetes/admin.conf"
   when: not admin_conf_stat.stat.exists
   register: kubeadm_pri_result
-  notify: Restart haproxy on primary master
+  notify:
+    - Restart haproxy on primary master
+    - Restart kubelet
 
-- name: "C8. Verify that admin.conf was created"
+- name: "C10. Verify that admin.conf was created"
   ansible.builtin.stat:
     path: "/etc/kubernetes/admin.conf"
   register: admin_conf_stat_post_init
 
-- name: "C9. Fail if kubeadm init did not create admin.conf"
+- name: "C11. Fail if kubeadm init did not create admin.conf"
   ansible.builtin.fail:
     msg: "kubeadm init failed to create /etc/kubernetes/admin.conf. Check /tmp/kubeadm-init.log for details."
   when: not admin_conf_stat_post_init.stat.exists and kubeadm_pri_result is changed
 
-- name: "C10. Create .kube directory for the root user"
+- name: "C12. Create .kube directory for the root user"
   ansible.builtin.file:
     path: "/root/.kube"
     state: directory
     mode: "0755"
 
-- name: "C11. Copy admin.conf to root's kube config"
+- name: "C13. Copy admin.conf to root's kube config"
   ansible.builtin.copy:
     src: "/etc/kubernetes/admin.conf"
     dest: "/root/.kube/config"
     remote_src: true
     mode: "0600"
 
-- name: "C12. Create .kube directory for the SSH user"
+- name: "C14. Create .kube directory for the SSH user"
   ansible.builtin.file:
     path: "/home/{{ ansible_user }}/.kube"
     state: directory
@@ -76,7 +103,7 @@
     group: "{{ ansible_user }}"
     mode: "0755"
 
-- name: "C13. Copy admin.conf to user's kube config"
+- name: "C15. Copy admin.conf to user's kube config"
   ansible.builtin.copy:
     src: "/etc/kubernetes/admin.conf"
     dest: "/home/{{ ansible_user }}/.kube/config"
@@ -85,7 +112,7 @@
     group: "{{ ansible_user }}"
     mode: "0644"
 
-- name: "C14. Fetch admin.conf to a predictable local path"
+- name: "C16. Fetch admin.conf to a predictable local path"
   ansible.builtin.fetch:
     src: "/etc/kubernetes/admin.conf"
     dest: "{{ kubeadm_fetched_kubeconfig_path }}"

--- a/ansible/roles/30-kubeadm/tasks/E-join-secondary.yaml
+++ b/ansible/roles/30-kubeadm/tasks/E-join-secondary.yaml
@@ -1,32 +1,39 @@
 ---
-- name: "Block E1: Prepare secondary master node for joining"
+- name: "E1. Check if node is already joined"
+  ansible.builtin.stat:
+    path: "/etc/kubernetes/kubelet.conf"
+  register: kubelet_conf_stat
+
+- name: "E2. Prepare secondary master node for joining"
+  when: not kubelet_conf_stat.stat.exists
   block:
-    - name: "E1a. Reset any previous kubeadm configuration"
+    - name: "E2a. Reset any previous kubeadm configuration"
       ansible.builtin.command:
         cmd: "kubeadm reset -f"
       changed_when: true
 
-    - name: "E1b. Ensure kubelet service is enabled"
+    - name: "E2b. Ensure kubelet service is enabled"
       ansible.builtin.systemd:
         name: "kubelet"
         enabled: true
 
-- name: "Block E2: Join this node to the control plane"
+- name: "E3. Join this node to the control plane"
+  when: not kubelet_conf_stat.stat.exists
   block:
-    - name: "E2a. Create kubeadm join config file from template"
+    - name: "E3a. Create kubeadm join config file from template"
       ansible.builtin.template:
         src: kubeadm-join-secondary-config.yaml.j2
         dest: "/tmp/kubeadm-join-config.yaml"
         mode: "0644"
 
-    - name: "E2b. Wait for API Server VIP to be reachable before joining"
+    - name: "E3b. Wait for API Server VIP to be reachable before joining"
       ansible.builtin.wait_for:
         host: "{{ kubeadm_ha_virtual_ip }}"
         port: 6443
         state: started
         timeout: 30
 
-    - name: "E2c. Execute the control-plane join command"
+    - name: "E3c. Execute the control-plane join command"
       ansible.builtin.command: >-
         kubeadm join
         --config=/tmp/kubeadm-join-config.yaml
@@ -36,7 +43,7 @@
       register: kubeadm_join_result
       no_log: true
 
-    - name: "E2d. Fail if kubeadm join command failed"
+    - name: "E3d. Fail if kubeadm join command failed"
       ansible.builtin.fail:
         msg: |
           kubeadm join failed on {{ inventory_hostname }}.
@@ -44,22 +51,22 @@
           STDERR: {{ kubeadm_join_result.stderr | default('N/A') }}
       when: kubeadm_join_result.rc is defined and kubeadm_join_result.rc != 0
 
-- name: "Block E3: Set up kubeconfig on this secondary master"
+- name: "E4. Set up kubeconfig on this secondary master"
   block:
-    - name: "E3a. Create .kube directory for the root user"
+    - name: "E4a. Create .kube directory for the root user"
       ansible.builtin.file:
         path: "/root/.kube"
         state: directory
         mode: "0755"
 
-    - name: "E3b. Copy admin.conf to root's kube config"
+    - name: "E4b. Copy admin.conf to root's kube config"
       ansible.builtin.copy:
         src: "/etc/kubernetes/admin.conf"
         dest: "/root/.kube/config"
         remote_src: true
         mode: "0600"
 
-    - name: "E3c. Create .kube directory for the SSH user"
+    - name: "E4c. Create .kube directory for the SSH user"
       ansible.builtin.file:
         path: "/home/{{ ansible_user }}/.kube"
         state: directory
@@ -67,7 +74,7 @@
         group: "{{ ansible_user }}"
         mode: "0755"
 
-    - name: "E3d. Copy admin.conf to user's kube config"
+    - name: "E4d. Copy admin.conf to user's kube config"
       ansible.builtin.copy:
         src: "/etc/kubernetes/admin.conf"
         dest: "/home/{{ ansible_user }}/.kube/config"
@@ -75,3 +82,10 @@
         owner: "{{ ansible_user }}"
         group: "{{ ansible_user }}"
         mode: "0644"
+
+- name: "E5. Upgrade local kubelet configuration from cluster ConfigMap"
+  ansible.builtin.command: >-
+    kubeadm upgrade node phase kubelet-config
+  changed_when: true
+  notify: "Restart kubelet"
+  when: kubelet_conf_stat.stat.exists and hostvars[groups['master'][0]]['kubeadm_config_result'].changed | default(false)

--- a/ansible/roles/30-kubeadm/tasks/F-join-workers.yaml
+++ b/ansible/roles/30-kubeadm/tasks/F-join-workers.yaml
@@ -1,36 +1,50 @@
 ---
-- name: "Block F1: Prepare worker node for joining"
+- name: "F1. Check if node is already joined"
+  ansible.builtin.stat:
+    path: "/etc/kubernetes/kubelet.conf"
+  register: kubelet_conf_stat
+
+- name: "F2. Prepare worker node for joining"
+  when: not kubelet_conf_stat.stat.exists
   block:
-    - name: "F1a. Reset any previous kubeadm configuration"
+    - name: "F2a. Reset any previous kubeadm configuration"
       ansible.builtin.command:
         cmd: "kubeadm reset -f"
       changed_when: true
 
-    - name: "F1b. Ensure kubelet service is enabled and started"
+    - name: "F2b. Ensure kubelet service is enabled and started"
       ansible.builtin.systemd:
         name: "kubelet"
         state: started
         enabled: true
 
-- name: "Block F2: Join this worker node to the cluster"
+- name: "F3. Join this worker node to the cluster"
+  when: not kubelet_conf_stat.stat.exists
   block:
-    - name: "F2a. Create kubeadm join config file from template"
+    - name: "F3a. Create kubeadm join config file from template"
       ansible.builtin.template:
         src: kubeadm-join-workers-config.yaml.j2
         dest: "/tmp/kubeadm-join-config.yaml"
         mode: "0644"
 
-    - name: "F2b. Execute the worker join command"
+    - name: "F3b. Execute the worker join command"
       ansible.builtin.command: >-
         kubeadm join --config=/tmp/kubeadm-join-config.yaml
       args:
         creates: "/etc/kubernetes/kubelet.conf"
       register: kubeadm_join_result
 
-    - name: "F2c. Fail if kubeadm join command failed"
+    - name: "F3c. Fail if kubeadm join command failed"
       ansible.builtin.fail:
         msg: |
           kubeadm join failed on {{ inventory_hostname }}.
           STDOUT: {{ kubeadm_join_result.stdout | default('N/A') }}
           STDERR: {{ kubeadm_join_result.stderr | default('N/A') }}
       when: kubeadm_join_result.rc is defined and kubeadm_join_result.rc != 0
+
+- name: "F4. Upgrade local kubelet configuration from cluster ConfigMap"
+  ansible.builtin.command: >-
+    kubeadm upgrade node phase kubelet-config
+  changed_when: true
+  notify: "Restart kubelet"
+  when: kubelet_conf_stat.stat.exists and hostvars[groups['master'][0]]['kubeadm_config_result'].changed | default(false)

--- a/ansible/roles/30-kubeadm/templates/kubeadm-config.yaml.j2
+++ b/ansible/roles/30-kubeadm/templates/kubeadm-config.yaml.j2
@@ -47,3 +47,7 @@ etcd:
 {% for ip in kubeadm_master_ips %}
       - "{{ ip }}"
 {% endfor %}
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+serverTLSBootstrap: true

--- a/ansible/roles/40-harbor-provision/defaults/main.yaml
+++ b/ansible/roles/40-harbor-provision/defaults/main.yaml
@@ -44,3 +44,8 @@ helm_charts_to_sync: # List of Helm Charts to Synchronize
     version: "0.85.0"
     repo: "https://charts.gitlab.io/"
     is_oci: false
+
+  - name: "kubelet-csr-approver"
+    version: "1.2.14"
+    repo: "oci://ghcr.io/postfinance/charts"
+    is_oci: true

--- a/terraform/layers/30-infra-gitlab-frontend/output.tf
+++ b/terraform/layers/30-infra-gitlab-frontend/output.tf
@@ -4,6 +4,11 @@ output "service_vip" {
   value       = local.p_net_config.lb_config.vip
 }
 
+output "cluster_name" {
+  description = "The name of the Cluster from the metadata"
+  value       = local.svc_identity.cluster_name
+}
+
 output "credentials_system" {
   description = "System-level access credentials for the cluster nodes."
   value       = local.sec_vm_creds

--- a/terraform/layers/50-platform-gitlab/locals.tf
+++ b/terraform/layers/50-platform-gitlab/locals.tf
@@ -112,15 +112,19 @@ locals {
 
 # 5. DNS Configuration (Standardized)
 locals {
-  dns_hosts = {
-    "${local.state.kubeadm.service_vip}"         = local.fqdn_gitlab
-    "${local.state.vault_pki.vault_service_vip}" = local.fqdn_vault
+  dns_hosts = merge(
+    {
+      "${local.state.kubeadm.service_vip}"         = local.fqdn_gitlab
+      "${local.state.vault_pki.vault_service_vip}" = local.fqdn_vault
 
-    # Dependency Roles
-    "${local.state.redis.service_vip}"    = local.fqdn_redis
-    "${local.state.postgres.service_vip}" = local.fqdn_postgres
-    "${local.state.minio.service_vip}"    = local.fqdn_minio
-  }
+      # Dependency Roles
+      "${local.state.redis.service_vip}"    = local.fqdn_redis
+      "${local.state.postgres.service_vip}" = local.fqdn_postgres
+      "${local.state.minio.service_vip}"    = local.fqdn_minio
+    },
+    # Dynamic Node Resolution (Required for Kubelet CSR Approver DNS checks)
+    { for node_name, node in local.state.kubeadm.topology_cluster : node.ip => node_name }
+  )
 }
 
 # 6. CA Bundle Configuration

--- a/terraform/layers/50-platform-gitlab/locals.tf
+++ b/terraform/layers/50-platform-gitlab/locals.tf
@@ -56,6 +56,8 @@ locals {
   harbor_k8s_proxy    = local.state.harbor_bootstrapper.proxy_caches.k8s_io.project_name
   harbor_docker_proxy = local.state.harbor_bootstrapper.proxy_caches.docker_hub.project_name
   harbor_gitlab_proxy = local.state.harbor_bootstrapper.proxy_caches.gitlab_com.project_name
+  harbor_ghcr_proxy   = local.state.harbor_bootstrapper.proxy_caches.ghcr_io.project_name
+  harbor_gcr_proxy    = local.state.harbor_bootstrapper.proxy_caches.gcr_io.project_name
   helm_chart_project  = local.state.harbor_bootstrapper.proxy_oci.helm_charts.name
 
   # GitLab CNG image registry and repository routed through Harbor Bootstrapper proxy
@@ -79,6 +81,9 @@ locals {
   vault_role_name   = local.state.metadata.global_pki_map["gitlab-frontend"].role_name
   vault_auth_path   = local.state.metadata.global_pki_map["gitlab-frontend"].auth_config.path
   vault_policy_name = "${local.vault_role_name}-pki-policy"
+
+  # Kubelet Serving Certificate Approval Configuration
+  node_serving_cert_regex = "^${local.state.kubeadm.cluster_name}-.*$"
 }
 
 # 4. External Service Address & Ports

--- a/terraform/layers/50-platform-gitlab/main.tf
+++ b/terraform/layers/50-platform-gitlab/main.tf
@@ -63,13 +63,13 @@ module "kubelet_csr_approver" {
   source = "../../modules/kubernetes-addons/kubelet-csr-approver"
   helm_config = {
     install          = true
+    create_namespace = false # Already in kube-system
     version          = var.csr_approver_config.version
     namespace        = var.csr_approver_config.namespace
-    create_namespace = false # Already in kube-system
-    image_registry   = local.harbor_registry
-    image_repository = "${local.harbor_ghcr_proxy}/postfinance"
-    chart_project    = local.helm_chart_project
     image_tag        = "v${var.csr_approver_config.version}"
+    image_repository = "${local.harbor_ghcr_proxy}/postfinance"
+    image_registry   = local.harbor_registry
+    chart_project    = local.helm_chart_project
     provider_regex   = local.node_serving_cert_regex
   }
 }

--- a/terraform/layers/50-platform-gitlab/main.tf
+++ b/terraform/layers/50-platform-gitlab/main.tf
@@ -59,6 +59,21 @@ module "platform_trust_engine" {
   depends_on = [module.tigera_calico]
 }
 
+module "kubelet_csr_approver" {
+  source = "../../modules/kubernetes-addons/kubelet-csr-approver"
+  helm_config = {
+    install          = true
+    version          = var.csr_approver_config.version
+    namespace        = var.csr_approver_config.namespace
+    create_namespace = false # Already in kube-system
+    image_registry   = local.harbor_registry
+    image_repository = "${local.harbor_ghcr_proxy}/postfinance"
+    chart_project    = local.helm_chart_project
+    image_tag        = "v${var.csr_approver_config.version}"
+    provider_regex   = local.node_serving_cert_regex
+  }
+}
+
 module "metric_server" {
   source = "../../modules/kubernetes-addons/metric-server"
   helm_config = {
@@ -70,7 +85,7 @@ module "metric_server" {
     image_repository = "${local.harbor_k8s_proxy}/metrics-server"
     chart_project    = local.helm_chart_project
   }
-  depends_on = [module.platform_trust_engine]
+  depends_on = [module.kubelet_csr_approver]
 }
 
 module "ingress_nginx" {

--- a/terraform/layers/50-platform-gitlab/variables.tf
+++ b/terraform/layers/50-platform-gitlab/variables.tf
@@ -43,6 +43,20 @@ variable "metric_server_config" {
   }
 }
 
+variable "csr_approver_config" {
+  description = "Configuration for Kubelet CSR Approver"
+  type = object({
+    version        = string
+    namespace      = string
+    provider_regex = string
+  })
+  default = {
+    version        = "1.2.14"
+    namespace      = "kube-system"
+    provider_regex = ""
+  }
+}
+
 variable "ingress_nginx_config" {
   description = "Configuration for Ingress Nginx"
   type = object({

--- a/terraform/modules/kubernetes-addons/kubelet-csr-approver/main.tf
+++ b/terraform/modules/kubernetes-addons/kubelet-csr-approver/main.tf
@@ -1,0 +1,25 @@
+resource "helm_release" "kubelet_csr_approver" {
+  count = var.helm_config.install ? 1 : 0
+
+  name             = "kubelet-csr-approver"
+  chart            = "oci://${var.helm_config.image_registry}/${var.helm_config.chart_project}/kubelet-csr-approver"
+  namespace        = var.helm_config.namespace
+  version          = var.helm_config.version
+  create_namespace = var.helm_config.create_namespace
+  cleanup_on_fail  = true
+
+  set = [
+    {
+      name  = "image.repository"
+      value = "${var.helm_config.image_registry}/${var.helm_config.image_repository}/kubelet-csr-approver"
+    },
+    {
+      name  = "image.tag"
+      value = var.helm_config.image_tag
+    },
+    {
+      name  = "provider.regex"
+      value = var.helm_config.provider_regex
+    }
+  ]
+}

--- a/terraform/modules/kubernetes-addons/kubelet-csr-approver/variables.tf
+++ b/terraform/modules/kubernetes-addons/kubelet-csr-approver/variables.tf
@@ -1,0 +1,14 @@
+variable "helm_config" {
+  description = "Configuration for the kubelet-csr-approver Helm release"
+  type = object({
+    install          = bool
+    namespace        = string
+    create_namespace = bool
+    version          = string
+    image_registry   = string
+    chart_project    = string
+    image_repository = string
+    image_tag        = string
+    provider_regex   = string
+  })
+}

--- a/terraform/modules/kubernetes-addons/metric-server/main.tf
+++ b/terraform/modules/kubernetes-addons/metric-server/main.tf
@@ -13,10 +13,6 @@ resource "helm_release" "metrics_server" {
     {
       name  = "image.repository"
       value = "${var.helm_config.image_registry}/${var.helm_config.image_repository}/metrics-server"
-    },
-    {
-      name  = "args[0]"
-      value = "--kubelet-insecure-tls"
     }
   ]
 }


### PR DESCRIPTION
## Summary

This PR primarily addresses the long-standing use of `--insecure-tls` in the Metrics Server configuration, which left the system vulnerable to Man-in-the-Middle (MITM) attacks. It also fixes several idempotency errors in the Ansible playbooks used during the cluster bootstrapping process.

If a malicious node or a compromised Pod exists within the same physical network or VXLAN, it could intercept requests from the Metrics Server to the Kubelets and return forged CPU load data. Because the Metrics Server was not validating certificates, it would blindly trust this fabricated data. This could directly lead to the failure of Kubernetes Horizontal Pod Autoscaling (HPA). For instance, forged data reporting 100% CPU utilization could force the cluster to launch a massive number of unnecessary Pods, eventually exhausting all physical server resources.

## Changes

### Core Architecture

1. **Kubelet TLS & Metrics Server**: Deployed `kubelet-csr-approver` to automate certificate signing. Integrated node IP mappings into CoreDNS to satisfy SAN DNS validation for secure metrics collection.
2. **Infrastructure Stability**: Hardened network interface discovery to prevent VIP drift and refactored Ansible tasks for full idempotency, eliminating unnecessary service restarts.

### Fixes & Technical Debt

- **Kubeadm Network Discovery**:
    - _Problem_: Dynamic interface detection picked up virtual/CNI interfaces (e.g., `vxlan.calico`) instead of physical host-only interfaces, causing incorrect API Server advertisement and VIP instability.
    - _Solution_: Hardened filtering in `A-prerequisites.yaml` to explicitly exclude virtual interface patterns, ensuring stable host network binding.
- **Ansible Execution Failure**:
    - _Problem_: Non-idempotent tasks (e.g., mandatory `journald` restarts) caused inconsistent state reporting, which led to intermittent execution failures when triggered via Terraform's `ansible_runner`.
    - _Solution_: Refactored service restarts and task dependencies to ensure that repeated playbook execution completes successfully without causing cluster corruption or unexpected service downtime.

### Refactoring

- **Ansible Idempotency & Linting**: Refactored `systemd-journald` restarts into handlers and re-indexed tasks to resolve `ansible-lint` violations and ensure stable infrastructure state across repeated runs.

### Verification

- [x] **Metrics Server**: Verified `kubectl top nodes` is functional and TLS errors are resolved.

    ```text
    $ kubectl top nodes
    NAME                             CPU(cores)   CPU(%)   MEMORY(bytes)   MEMORY(%)
    core-gitlab-frontend-master-00   367m         9%       1514Mi          52%
    core-gitlab-frontend-worker-10   43m          1%       2993Mi          51%
    core-gitlab-frontend-worker-11   213m         5%       2831Mi          48%
    ```

    ```text
    $ kubectl get csr
    NAME        AGE     SIGNERNAME                                    REQUESTOR                                    REQUESTEDDURATION   CONDITION
    csr-dqz75   51m     kubernetes.io/kube-apiserver-client-kubelet   system:bootstrap:0dv5f7                      <none>              Approved,Issued
    csr-gzfn7   25m     kubernetes.io/kubelet-serving                 system:node:core-gitlab-frontend-master-00   <none>              Approved,Issued
    csr-mxwtz   4m4s    kubernetes.io/kubelet-serving                 system:node:core-gitlab-frontend-worker-11   <none>              Approved,Issued
    csr-jnmjq   5m8s    kubernetes.io/kubelet-serving                 system:node:core-gitlab-frontend-worker-10   <none>              Approved,Issued
    ```

- [x] **VIP Access**: Verified stable API connectivity via `172.16.126.250` following network interface hardening.
- [x] **Idempotency**:
    - Verified repeated execution does not trigger unnecessary service restarts.
    - Reexecuting ansible playbook does not destroy the cluster.
