### PR TITLE
refactor(clb/haproxy): Decouple Health Check SSL Logic from Service Names

### DIFF
--- a/ansible/roles/10-load-balancer/defaults/main.yaml
+++ b/ansible/roles/10-load-balancer/defaults/main.yaml
@@ -16,3 +16,4 @@ central_lb_sysctl_hardening:
 haproxy_health_check_inter: "10s"
 haproxy_health_check_fall: "5"
 haproxy_health_check_rise: "3"
+haproxy_ca_path: "/etc/haproxy/certs/ca.crt"

--- a/ansible/roles/10-load-balancer/tasks/B-service-config.yaml
+++ b/ansible/roles/10-load-balancer/tasks/B-service-config.yaml
@@ -23,7 +23,7 @@
     - name: "B1c. Deploy Root CA (For Backend Verification)"
       ansible.builtin.copy:
         content: "{{ vault_ca_cert | b64decode }}"
-        dest: /etc/haproxy/certs/ca.crt
+        dest: "{{ haproxy_ca_path }}"
         owner: haproxy
         group: haproxy
         mode: "0644"

--- a/ansible/roles/10-load-balancer/templates/haproxy.cfg.j2
+++ b/ansible/roles/10-load-balancer/templates/haproxy.cfg.j2
@@ -59,9 +59,9 @@ backend {{ backend_name }}
     {% if port_cfg.health_check_type == 'http' %}
     option httpchk GET {{ port_cfg.health_check_http_path | default('/') }}
     http-check expect {{ port_cfg.health_check_http_expect | default('status 200') }}
-    {% endif %} 
+    {% endif %}
     {% for server in segment.backend_servers %}
-    server {{ server.name }} {{ server.ip }}:{{ port_cfg.backend }} check{% if port_cfg.health_check_port %} port {{ port_cfg.health_check_port }}{% endif %} inter {{ haproxy_health_check_inter }} fall {{ haproxy_health_check_fall }} rise {{ haproxy_health_check_rise }}{% if port_cfg.health_check_ssl | default(false) or 'vault' in segment.name %} check-ssl verify none{% endif %} {% if port_cfg.send_proxy_v2 | default(false) %} send-proxy-v2{% endif %} 
+    server {{ server.name }} {{ server.ip }}:{{ port_cfg.backend }} check{% if port_cfg.health_check_port %} port {{ port_cfg.health_check_port }}{% endif %} inter {{ haproxy_health_check_inter }} fall {{ haproxy_health_check_fall }} rise {{ haproxy_health_check_rise }}{% if port_cfg.health_check_ssl | default(false) %} check-ssl verify none{% endif %}{% if port_cfg.send_proxy_v2 | default(false) %} send-proxy-v2{% endif %}
     {% endfor %}
 {% endfor %}
 {% endif %}

--- a/ansible/roles/10-load-balancer/templates/haproxy.cfg.j2
+++ b/ansible/roles/10-load-balancer/templates/haproxy.cfg.j2
@@ -61,7 +61,8 @@ backend {{ backend_name }}
     http-check expect {{ port_cfg.health_check_http_expect | default('status 200') }}
     {% endif %}
     {% for server in segment.backend_servers %}
-    server {{ server.name }} {{ server.ip }}:{{ port_cfg.backend }} check{% if port_cfg.health_check_port %} port {{ port_cfg.health_check_port }}{% endif %} inter {{ haproxy_health_check_inter }} fall {{ haproxy_health_check_fall }} rise {{ haproxy_health_check_rise }}{% if port_cfg.health_check_ssl | default(false) %} check-ssl verify none{% endif %}{% if port_cfg.send_proxy_v2 | default(false) %} send-proxy-v2{% endif %}
+    server {{ server.name }} {{ server.ip }}:{{ port_cfg.backend }} check{% if port_cfg.health_check_port %} port {{ port_cfg.health_check_port }}{% endif %} inter {{ haproxy_health_check_inter }} fall {{ haproxy_health_check_fall }} rise {{ haproxy_health_check_rise }}{% if port_cfg.health_check_ssl | default(false) %} check-ssl verify required ca-file {{ haproxy_ca_path }}{% endif %}{% if port_cfg.send_proxy_v2 | default(false) %} send-proxy-v2{% endif %}
+
     {% endfor %}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
### Refactor

- Removed hardcoded `vault` in `segment.name` checks from the HAProxy configuration template. As described in #110
- Refactored health check logic to rely exclusively on the `health_check_ssl` flag provided by the service catalog.
- Implemented backend certificate verification using the internal Root CA (`ca.crt` from Podman Vault) for all SSL health checks.

### Veritication

- [x] **Idempotency**: consistent rendering on LB nodes, ensuring a more generic and maintainable orchestration pattern.
- [x] **Cluster Status** keeps operating without service down.