### PR TITLE
refactor(pki/base64): Standardize PKI Artifacts with Base64 Suffix and `kv_v2` Migration

### DIFF
--- a/ansible/roles/10-load-balancer/tasks/B-service-config.yaml
+++ b/ansible/roles/10-load-balancer/tasks/B-service-config.yaml
@@ -12,22 +12,22 @@
 
     - name: "B1b. Deploy Vault HAProxy Bundle (Cert + Key)"
       ansible.builtin.copy:
-        content: "{{ vault_haproxy_bundle | b64decode }}"
+        content: "{{ vault_haproxy_bundle_b64 | b64decode }}"
         dest: /etc/haproxy/certs/vault.pem
         owner: haproxy
         group: haproxy
         mode: "0600"
-      when: vault_haproxy_bundle is defined
+      when: vault_haproxy_bundle_b64 is defined
       notify: Restart HAProxy
 
     - name: "B1c. Deploy Root CA (For Backend Verification)"
       ansible.builtin.copy:
-        content: "{{ vault_ca_cert | b64decode }}"
+        content: "{{ vault_ca_cert_b64 | b64decode }}"
         dest: "{{ haproxy_ca_path }}"
         owner: haproxy
         group: haproxy
         mode: "0644"
-      when: vault_ca_cert is defined
+      when: vault_ca_cert_b64 is defined
       notify: Restart HAProxy
 
 - name: "Block B2: Configure Keepalived and HAProxy"

--- a/ansible/roles/15-vault/tasks/A-setup.yaml
+++ b/ansible/roles/15-vault/tasks/A-setup.yaml
@@ -39,7 +39,7 @@
 
 - name: "Block A2: Deploy Vault TLS Certificates"
   become: true
-  when: vault_server_cert is defined
+  when: vault_server_cert_b64 is defined
   block:
     - name: "A2a. Ensure Vault TLS directory exists with secure permissions"
       ansible.builtin.file:
@@ -51,7 +51,7 @@
 
     - name: "A2b. Deploy Vault Server Certificate"
       ansible.builtin.copy:
-        content: "{{ vault_server_cert | b64decode }}"
+        content: "{{ vault_server_cert_b64 | b64decode }}"
         dest: "{{ vault_dir_tls }}/vault.crt"
         owner: vault
         group: vault
@@ -60,7 +60,7 @@
 
     - name: "A2c. Deploy Vault Server Private Key"
       ansible.builtin.copy:
-        content: "{{ vault_server_key | b64decode }}"
+        content: "{{ vault_server_key_b64 | b64decode }}"
         dest: "{{ vault_dir_tls }}/vault.key"
         owner: vault
         group: vault
@@ -69,7 +69,7 @@
 
     - name: "A2d. Deploy Vault CA Certificate"
       ansible.builtin.copy:
-        content: "{{ vault_ca_cert | b64decode }}"
+        content: "{{ vault_ca_cert_b64 | b64decode }}"
         dest: "{{ vault_dir_tls }}/vault-ca.crt"
         owner: vault
         group: vault
@@ -78,7 +78,7 @@
 
     - name: "A2e. Trust Vault Root CA on OS level"
       ansible.builtin.copy:
-        content: "{{ vault_ca_cert | b64decode }}"
+        content: "{{ vault_ca_cert_b64 | b64decode }}"
         dest: /usr/local/share/ca-certificates/vault-ca.crt
         mode: "0644"
         owner: root

--- a/terraform/layers/00-foundation-metadata/outputs.tf
+++ b/terraform/layers/00-foundation-metadata/outputs.tf
@@ -64,13 +64,13 @@ output "global_pki_map" {
   value       = local.pki_map
 }
 
-output "global_vault_pki" {
+output "global_vault_pki_b64" {
   description = "Base64 encoded TLS artifacts for the Bootstrap Vault instance."
   sensitive   = true
   value = {
-    ca_cert        = base64encode(tls_self_signed_cert.root_ca.cert_pem)
-    server_cert    = base64encode(tls_locally_signed_cert.vault_server.cert_pem)
-    server_key     = base64encode(tls_private_key.vault_server.private_key_pem)
-    haproxy_bundle = base64encode("${tls_locally_signed_cert.vault_server.cert_pem}\n${tls_private_key.vault_server.private_key_pem}")
+    ca_cert_b64        = base64encode(tls_self_signed_cert.root_ca.cert_pem)
+    server_cert_b64    = base64encode(tls_locally_signed_cert.vault_server.cert_pem)
+    server_key_b64     = base64encode(tls_private_key.vault_server.private_key_pem)
+    haproxy_bundle_b64 = base64encode("${tls_locally_signed_cert.vault_server.cert_pem}\n${tls_private_key.vault_server.private_key_pem}")
   }
 }

--- a/terraform/layers/10-shared-load-balancer-frontend/locals.tf
+++ b/terraform/layers/10-shared-load-balancer-frontend/locals.tf
@@ -72,7 +72,7 @@ locals {
 
 # 3. Security & Credentials Context (sec_ / pki_)
 locals {
-  pki_global_ca = local.state.metadata.global_vault_pki
+  pki_global_ca_b64 = local.state.metadata.global_vault_pki_b64
 
   # System Level Credentials (OS/SSH)
   sec_vm_creds = {

--- a/terraform/layers/10-shared-load-balancer-frontend/main.tf
+++ b/terraform/layers/10-shared-load-balancer-frontend/main.tf
@@ -19,7 +19,7 @@ module "central_lb_cluster" {
   svc_network_map = local.network_map
 
   # Secrets & PKI
-  security_pki_bundle     = local.pki_global_ca
+  security_pki_bundle_b64 = local.pki_global_ca_b64
   credentials_vm          = local.sec_vm_creds
   credentials_application = local.sec_haproxy_creds
 

--- a/terraform/layers/15-shared-vault-frontend/locals.tf
+++ b/terraform/layers/15-shared-vault-frontend/locals.tf
@@ -49,7 +49,7 @@ locals {
 
 # 3. Security & Credentials Context (sec_ / pki_)
 locals {
-  pki_global_ca = local.state.metadata.global_vault_pki # PKI Artifacts
+  pki_global_ca_b64 = local.state.metadata.global_vault_pki_b64 # PKI Artifacts
 
   # System Level Credentials (OS/SSH)
   sec_vm_creds = {
@@ -110,10 +110,10 @@ locals {
       dev_vault_url      = var.vault_dev_addr
       dev_vault_api_path = "on-premise-gitlab-deployment/credentials"
     },
-    local.pki_global_ca != null && length(keys(local.pki_global_ca)) > 0 ? {
-      vault_server_cert = local.pki_global_ca.server_cert
-      vault_server_key  = local.pki_global_ca.server_key
-      vault_ca_cert     = local.pki_global_ca.ca_cert
+    local.pki_global_ca_b64 != null && length(keys(local.pki_global_ca_b64)) > 0 ? {
+      vault_server_cert_b64 = local.pki_global_ca_b64.server_cert_b64
+      vault_server_key_b64  = local.pki_global_ca_b64.server_key_b64
+      vault_ca_cert_b64     = local.pki_global_ca_b64.ca_cert_b64
     } : {}
   )
 }

--- a/terraform/layers/15-shared-vault-frontend/main.tf
+++ b/terraform/layers/15-shared-vault-frontend/main.tf
@@ -3,7 +3,7 @@
 # This ensures downstream layers (e.g. 20-vault-pki) can reference it
 # as ca_cert_file without a circular dependency during provider initialization.
 resource "local_file" "bootstrap_ca" {
-  content         = base64decode(local.pki_global_ca.ca_cert)
+  content         = base64decode(local.pki_global_ca_b64.ca_cert_b64)
   filename        = "${path.root}/tls/bootstrap-ca.crt"
   file_permission = "0644"
 }

--- a/terraform/layers/15-shared-vault-frontend/outputs.tf
+++ b/terraform/layers/15-shared-vault-frontend/outputs.tf
@@ -10,9 +10,9 @@ output "credentials_system" {
   sensitive   = true
 }
 
-output "security_pki_bundle" {
+output "security_pki_bundle_b64" {
   description = "The PKI bundle for the Vault server."
-  value       = local.pki_global_ca
+  value       = local.pki_global_ca_b64
   sensitive   = true
 }
 

--- a/terraform/layers/20-security-vault-approle/locals.tf
+++ b/terraform/layers/20-security-vault-approle/locals.tf
@@ -30,7 +30,7 @@ locals {
       # [1] Data Plane (Business Data): Maintain strict least privilege,
       #     precisely scoped to specific projects and mount points.
       "secret/data/on-premise-gitlab-deployment/*"     = { capabilities = ["create", "read", "update", "delete"] }
-      "secret/metadata/on-premise-gitlab-deployment/*" = { capabilities = ["read", "list", "delete"] }
+      "secret/metadata/on-premise-gitlab-deployment/*" = { capabilities = ["create", "read", "update", "delete", "list"] }
       "secret/delete/on-premise-gitlab-deployment/*"   = { capabilities = ["update"] }
       "secret/destroy/on-premise-gitlab-deployment/*"  = { capabilities = ["update"] }
 

--- a/terraform/layers/25-security-pki/main.tf
+++ b/terraform/layers/25-security-pki/main.tf
@@ -1,8 +1,8 @@
 
 resource "local_file" "trust_bundle" {
   content  = <<EOT
-${chomp(base64decode(local.state.metadata.global_vault_pki.ca_cert))}
-${chomp(module.vault_pki_setup.pki_root_ca_certificate)}
+${chomp(base64decode(local.state.metadata.global_vault_pki_b64.ca_cert_b64))}
+${chomp(base64decode(module.vault_pki_setup.pki_root_ca_certificate_b64))}
 EOT
   filename = abspath("${path.module}/tls/trust-bundle.crt")
 }

--- a/terraform/layers/25-security-pki/outputs.tf
+++ b/terraform/layers/25-security-pki/outputs.tf
@@ -7,9 +7,9 @@ output "vault_service_vip" {
 output "pki_configuration" {
   description = "PKI Configuration Summary"
   value = {
-    path      = module.vault_pki_setup.vault_pki_path
-    pki_roles = module.vault_pki_setup.pki_roles
-    ca_cert   = base64encode(module.vault_pki_setup.pki_root_ca_certificate)
+    path        = module.vault_pki_setup.vault_pki_path
+    pki_roles   = module.vault_pki_setup.pki_roles
+    ca_cert_b64 = module.vault_pki_setup.pki_root_ca_certificate_b64
     lease_durations = {
       default = format("%dh", var.vault_pki_engine_config.default_lease_ttl_seconds / 3600)
       max     = format("%dh", var.vault_pki_engine_config.max_lease_ttl_seconds / 3600)
@@ -45,10 +45,10 @@ output "auth_backend_paths" {
   value       = module.vault_pki_setup.auth_backend_paths
 }
 
-output "bootstrap_ca" {
+output "bootstrap_ca_b64" {
   description = "Aggregated Trust Bundle (Bootstrap CA + PKI CA)"
   value = {
-    path    = local_file.trust_bundle.filename
-    content = base64encode(local_file.trust_bundle.content)
+    path        = local_file.trust_bundle.filename
+    content_b64 = base64encode(local_file.trust_bundle.content)
   }
 }

--- a/terraform/layers/30-infra-gitlab-frontend/data.tf
+++ b/terraform/layers/30-infra-gitlab-frontend/data.tf
@@ -55,7 +55,8 @@ data "terraform_remote_state" "harbor_proxy" {
   }
 }
 
-data "vault_generic_secret" "guest_vm" {
+data "vault_kv_secret_v2" "guest_vm" {
   provider = vault.production
-  path     = "secret/on-premise-gitlab-deployment/guest_vm"
+  mount    = "secret"
+  name     = "on-premise-gitlab-deployment/guest_vm"
 }

--- a/terraform/layers/30-infra-gitlab-frontend/locals.tf
+++ b/terraform/layers/30-infra-gitlab-frontend/locals.tf
@@ -2,12 +2,11 @@
 # 1. State Hub (Cross-Layer SSoT)
 locals {
   state = {
-    metadata  = data.terraform_remote_state.metadata.outputs
-    volume    = data.terraform_remote_state.volume.outputs
-    network   = data.terraform_remote_state.network.outputs
-    vault_sys = data.terraform_remote_state.vault_sys.outputs
-    vault_pki = data.terraform_remote_state.vault_pki.outputs
-    # Dependencies
+    metadata        = data.terraform_remote_state.metadata.outputs
+    volume          = data.terraform_remote_state.volume.outputs
+    network         = data.terraform_remote_state.network.outputs
+    vault_sys       = data.terraform_remote_state.vault_sys.outputs
+    vault_pki       = data.terraform_remote_state.vault_pki.outputs
     harbor_registry = data.terraform_remote_state.harbor_bootstrapper.outputs
     harbor_proxy    = data.terraform_remote_state.harbor_proxy.outputs
   }
@@ -76,7 +75,7 @@ locals {
     role_id       = local.state.vault_pki.workload_identities_approle[local.sec_vault_identity_key].role_id
     role_name     = local.state.vault_pki.pki_configuration.pki_roles[local.sec_vault_identity_key].name
     secret_id     = vault_approle_auth_backend_role_secret_id.kubeadm_agent.secret_id
-    ca_cert_b64   = local.state.vault_pki.bootstrap_ca.content
+    ca_cert_b64   = local.state.vault_pki.bootstrap_ca_b64.content_b64
     common_name   = local.svc_fqdn
   }
 

--- a/terraform/layers/30-infra-gitlab-frontend/locals.tf
+++ b/terraform/layers/30-infra-gitlab-frontend/locals.tf
@@ -60,10 +60,10 @@ locals {
 
   # System Level Credentials (OS/SSH)
   sec_vm_creds = {
-    username             = data.vault_generic_secret.guest_vm.data["vm_username"]
-    password             = data.vault_generic_secret.guest_vm.data["vm_password"]
-    ssh_public_key_path  = data.vault_generic_secret.guest_vm.data["ssh_public_key_path"]
-    ssh_private_key_path = data.vault_generic_secret.guest_vm.data["ssh_private_key_path"]
+    username             = data.vault_kv_secret_v2.guest_vm.data["vm_username"]
+    password             = data.vault_kv_secret_v2.guest_vm.data["vm_password"]
+    ssh_public_key_path  = data.vault_kv_secret_v2.guest_vm.data["ssh_public_key_path"]
+    ssh_private_key_path = data.vault_kv_secret_v2.guest_vm.data["ssh_private_key_path"]
   }
 
   # Vault Agent Physical Identity (Mapped to Component PKI)

--- a/terraform/layers/30-infra-gitlab-frontend/provider.tf
+++ b/terraform/layers/30-infra-gitlab-frontend/provider.tf
@@ -24,7 +24,7 @@ provider "libvirt" {
 provider "vault" {
   alias        = "production"
   address      = local.sys_vault_addr
-  ca_cert_file = local.state.vault_sys.ca_cert_path
+  ca_cert_file = local.state.vault_pki.bootstrap_ca_b64.path
 
   auth_login {
     path = "auth/approle/login"

--- a/terraform/layers/30-infra-gitlab-minio/data.tf
+++ b/terraform/layers/30-infra-gitlab-minio/data.tf
@@ -41,12 +41,14 @@ data "terraform_remote_state" "vault_pki" {
   }
 }
 
-data "vault_generic_secret" "guest_vm" {
+data "vault_kv_secret_v2" "guest_vm" {
   provider = vault.production
-  path     = "secret/on-premise-gitlab-deployment/guest_vm"
+  mount    = "secret"
+  name     = "on-premise-gitlab-deployment/guest_vm"
 }
 
-data "vault_generic_secret" "db_vars" {
+data "vault_kv_secret_v2" "db_vars" {
   provider = vault.production
-  path     = "secret/on-premise-gitlab-deployment/gitlab/databases"
+  mount    = "secret"
+  name     = "on-premise-gitlab-deployment/gitlab/databases"
 }

--- a/terraform/layers/30-infra-gitlab-minio/locals.tf
+++ b/terraform/layers/30-infra-gitlab-minio/locals.tf
@@ -64,17 +64,17 @@ locals {
 
   # System Credentials (OS/SSH)
   sec_system_creds = {
-    username             = data.vault_generic_secret.guest_vm.data["vm_username"]
-    password             = data.vault_generic_secret.guest_vm.data["vm_password"]
-    ssh_public_key_path  = data.vault_generic_secret.guest_vm.data["ssh_public_key_path"]
-    ssh_private_key_path = data.vault_generic_secret.guest_vm.data["ssh_private_key_path"]
+    username             = data.vault_kv_secret_v2.guest_vm.data["vm_username"]
+    password             = data.vault_kv_secret_v2.guest_vm.data["vm_password"]
+    ssh_public_key_path  = data.vault_kv_secret_v2.guest_vm.data["ssh_public_key_path"]
+    ssh_private_key_path = data.vault_kv_secret_v2.guest_vm.data["ssh_private_key_path"]
   }
 
   # Database Credentials (MinIO)
   sec_db_creds = {
-    minio_root_user     = data.vault_generic_secret.db_vars.data["minio_root_user"]
-    minio_root_password = data.vault_generic_secret.db_vars.data["minio_root_password"]
-    minio_vrrp_secret   = data.vault_generic_secret.db_vars.data["minio_vrrp_secret"]
+    minio_root_user     = data.vault_kv_secret_v2.db_vars.data["minio_root_user"]
+    minio_root_password = data.vault_kv_secret_v2.db_vars.data["minio_root_password"]
+    minio_vrrp_secret   = data.vault_kv_secret_v2.db_vars.data["minio_vrrp_secret"]
   }
 
   # Vault Agent Identity Prep

--- a/terraform/layers/30-infra-gitlab-minio/locals.tf
+++ b/terraform/layers/30-infra-gitlab-minio/locals.tf
@@ -86,7 +86,7 @@ locals {
     role_id       = local.state.vault_pki.workload_identities_approle[local.sec_vault_identity_key].role_id
     role_name     = local.state.vault_pki.pki_configuration.pki_roles[local.sec_vault_identity_key].name
     secret_id     = vault_approle_auth_backend_role_secret_id.minio_agent.secret_id
-    ca_cert_b64   = local.state.vault_pki.bootstrap_ca.content
+    ca_cert_b64   = local.state.vault_pki.bootstrap_ca_b64.content_b64
     common_name   = local.svc_fqdn
   }
 }

--- a/terraform/layers/30-infra-gitlab-minio/providers.tf
+++ b/terraform/layers/30-infra-gitlab-minio/providers.tf
@@ -20,7 +20,7 @@ provider "libvirt" {
 provider "vault" {
   alias        = "production"
   address      = local.sys_vault_addr
-  ca_cert_file = local.state.vault_pki.bootstrap_ca.path
+  ca_cert_file = local.state.vault_pki.bootstrap_ca_b64.path
 
   auth_login {
     path = "auth/approle/login"

--- a/terraform/layers/30-infra-gitlab-postgres/data.tf
+++ b/terraform/layers/30-infra-gitlab-postgres/data.tf
@@ -42,12 +42,14 @@ data "terraform_remote_state" "vault_pki" {
 }
 
 
-data "vault_generic_secret" "guest_vm" {
+data "vault_kv_secret_v2" "guest_vm" {
   provider = vault.production
-  path     = "secret/on-premise-gitlab-deployment/guest_vm"
+  mount    = "secret"
+  name     = "on-premise-gitlab-deployment/guest_vm"
 }
 
-data "vault_generic_secret" "db_vars" {
+data "vault_kv_secret_v2" "db_vars" {
   provider = vault.production
-  path     = "secret/on-premise-gitlab-deployment/gitlab/databases"
+  mount    = "secret"
+  name     = "on-premise-gitlab-deployment/gitlab/databases"
 }

--- a/terraform/layers/30-infra-gitlab-postgres/locals.tf
+++ b/terraform/layers/30-infra-gitlab-postgres/locals.tf
@@ -59,17 +59,17 @@ locals {
 
   # System Level Credentials (OS/SSH)
   sec_vm_creds = {
-    username             = data.vault_generic_secret.guest_vm.data["vm_username"]
-    password             = data.vault_generic_secret.guest_vm.data["vm_password"]
-    ssh_public_key_path  = data.vault_generic_secret.guest_vm.data["ssh_public_key_path"]
-    ssh_private_key_path = data.vault_generic_secret.guest_vm.data["ssh_private_key_path"]
+    username             = data.vault_kv_secret_v2.guest_vm.data["vm_username"]
+    password             = data.vault_kv_secret_v2.guest_vm.data["vm_password"]
+    ssh_public_key_path  = data.vault_kv_secret_v2.guest_vm.data["ssh_public_key_path"]
+    ssh_private_key_path = data.vault_kv_secret_v2.guest_vm.data["ssh_private_key_path"]
   }
 
   # Service Specific Credentials (DB/PG)
   sec_app_creds = {
-    replication_password = data.vault_generic_secret.db_vars.data["pg_replication_password"]
-    superuser_password   = data.vault_generic_secret.db_vars.data["pg_superuser_password"]
-    vrrp_secret          = data.vault_generic_secret.db_vars.data["pg_vrrp_secret"]
+    replication_password = data.vault_kv_secret_v2.db_vars.data["pg_replication_password"]
+    superuser_password   = data.vault_kv_secret_v2.db_vars.data["pg_superuser_password"]
+    vrrp_secret          = data.vault_kv_secret_v2.db_vars.data["pg_vrrp_secret"]
   }
 
   # Component Specific Vault Identities

--- a/terraform/layers/30-infra-gitlab-postgres/locals.tf
+++ b/terraform/layers/30-infra-gitlab-postgres/locals.tf
@@ -80,7 +80,7 @@ locals {
     role_id       = local.state.vault_pki.workload_identities_approle[local.sec_vault_role_key].role_id
     role_name     = local.state.vault_pki.pki_configuration.pki_roles[local.sec_vault_role_key].name
     secret_id     = vault_approle_auth_backend_role_secret_id.postgres_agent.secret_id
-    ca_cert_b64   = local.state.vault_pki.bootstrap_ca.content
+    ca_cert_b64   = local.state.vault_pki.bootstrap_ca_b64.content_b64
     common_name   = local.svc_fqdn
   }
 }

--- a/terraform/layers/30-infra-gitlab-postgres/providers.tf
+++ b/terraform/layers/30-infra-gitlab-postgres/providers.tf
@@ -20,7 +20,7 @@ provider "libvirt" {
 provider "vault" {
   alias        = "production"
   address      = local.sys_vault_addr
-  ca_cert_file = local.state.vault_pki.bootstrap_ca.path
+  ca_cert_file = local.state.vault_pki.bootstrap_ca_b64.path
 
   auth_login {
     path = "auth/approle/login"

--- a/terraform/layers/30-infra-gitlab-redis/data.tf
+++ b/terraform/layers/30-infra-gitlab-redis/data.tf
@@ -42,12 +42,14 @@ data "terraform_remote_state" "vault_pki" {
 }
 
 
-data "vault_generic_secret" "guest_vm" {
+data "vault_kv_secret_v2" "guest_vm" {
   provider = vault.production
-  path     = "secret/on-premise-gitlab-deployment/guest_vm"
+  mount    = "secret"
+  name     = "on-premise-gitlab-deployment/guest_vm"
 }
 
-data "vault_generic_secret" "db_vars" {
+data "vault_kv_secret_v2" "db_vars" {
   provider = vault.production
-  path     = "secret/on-premise-gitlab-deployment/gitlab/databases"
+  mount    = "secret"
+  name     = "on-premise-gitlab-deployment/gitlab/databases"
 }

--- a/terraform/layers/30-infra-gitlab-redis/locals.tf
+++ b/terraform/layers/30-infra-gitlab-redis/locals.tf
@@ -80,7 +80,7 @@ locals {
     role_id       = local.state.vault_pki.workload_identities_approle[local.sec_vault_role_key].role_id
     role_name     = local.state.vault_pki.pki_configuration.pki_roles[local.sec_vault_role_key].name
     secret_id     = vault_approle_auth_backend_role_secret_id.redis_agent.secret_id
-    ca_cert_b64   = local.state.vault_pki.bootstrap_ca.content
+    ca_cert_b64   = local.state.vault_pki.bootstrap_ca_b64.content_b64
     common_name   = local.svc_fqdn
   }
 }

--- a/terraform/layers/30-infra-gitlab-redis/locals.tf
+++ b/terraform/layers/30-infra-gitlab-redis/locals.tf
@@ -59,17 +59,17 @@ locals {
 
   # System Level Credentials (OS/SSH)
   sec_vm_creds = {
-    username             = data.vault_generic_secret.guest_vm.data["vm_username"]
-    password             = data.vault_generic_secret.guest_vm.data["vm_password"]
-    ssh_public_key_path  = data.vault_generic_secret.guest_vm.data["ssh_public_key_path"]
-    ssh_private_key_path = data.vault_generic_secret.guest_vm.data["ssh_private_key_path"]
+    username             = data.vault_kv_secret_v2.guest_vm.data["vm_username"]
+    password             = data.vault_kv_secret_v2.guest_vm.data["vm_password"]
+    ssh_public_key_path  = data.vault_kv_secret_v2.guest_vm.data["ssh_public_key_path"]
+    ssh_private_key_path = data.vault_kv_secret_v2.guest_vm.data["ssh_private_key_path"]
   }
 
   # Service Specific Credentials
   sec_app_creds = {
-    masterauth  = data.vault_generic_secret.db_vars.data["redis_masterauth"]
-    requirepass = data.vault_generic_secret.db_vars.data["redis_requirepass"]
-    vrrp_secret = data.vault_generic_secret.db_vars.data["redis_vrrp_secret"]
+    masterauth  = data.vault_kv_secret_v2.db_vars.data["redis_masterauth"]
+    requirepass = data.vault_kv_secret_v2.db_vars.data["redis_requirepass"]
+    vrrp_secret = data.vault_kv_secret_v2.db_vars.data["redis_vrrp_secret"]
   }
 
   # Component Specific Vault Identities

--- a/terraform/layers/30-infra-gitlab-redis/providers.tf
+++ b/terraform/layers/30-infra-gitlab-redis/providers.tf
@@ -20,7 +20,7 @@ provider "libvirt" {
 provider "vault" {
   alias        = "production"
   address      = local.sys_vault_addr
-  ca_cert_file = local.state.vault_pki.bootstrap_ca.path
+  ca_cert_file = local.state.vault_pki.bootstrap_ca_b64.path
 
   auth_login {
     path = "auth/approle/login"

--- a/terraform/layers/30-infra-gitlab-runner/data.tf
+++ b/terraform/layers/30-infra-gitlab-runner/data.tf
@@ -42,9 +42,10 @@ data "terraform_remote_state" "vault_pki" {
 }
 
 
-data "vault_generic_secret" "guest_vm" {
+data "vault_kv_secret_v2" "guest_vm" {
   provider = vault.production
-  path     = "secret/on-premise-gitlab-deployment/guest_vm"
+  mount    = "secret"
+  name     = "on-premise-gitlab-deployment/guest_vm"
 }
 
 data "terraform_remote_state" "harbor_bootstrapper" {

--- a/terraform/layers/30-infra-gitlab-runner/locals.tf
+++ b/terraform/layers/30-infra-gitlab-runner/locals.tf
@@ -57,7 +57,7 @@ locals {
     auth_path     = local.state.vault_pki.workload_identities_approle[local.sec_vault_identity_key].auth_path
     role_id       = local.state.vault_pki.workload_identities_approle[local.sec_vault_identity_key].role_id
     role_name     = local.state.vault_pki.pki_configuration.pki_roles[local.sec_vault_identity_key].name
-    ca_cert_b64   = local.state.vault_pki.bootstrap_ca.content
+    ca_cert_b64   = local.state.vault_pki.bootstrap_ca_b64.content_b64
     secret_id     = vault_approle_auth_backend_role_secret_id.microk8s_agent.secret_id
     common_name   = local.svc_fqdn
   }

--- a/terraform/layers/30-infra-gitlab-runner/locals.tf
+++ b/terraform/layers/30-infra-gitlab-runner/locals.tf
@@ -43,10 +43,10 @@ locals {
 
   # System Credentials (OS/SSH)
   sec_system_creds = {
-    username             = data.vault_generic_secret.guest_vm.data["vm_username"]
-    password             = data.vault_generic_secret.guest_vm.data["vm_password"]
-    ssh_public_key_path  = data.vault_generic_secret.guest_vm.data["ssh_public_key_path"]
-    ssh_private_key_path = data.vault_generic_secret.guest_vm.data["ssh_private_key_path"]
+    username             = data.vault_kv_secret_v2.guest_vm.data["vm_username"]
+    password             = data.vault_kv_secret_v2.guest_vm.data["vm_password"]
+    ssh_public_key_path  = data.vault_kv_secret_v2.guest_vm.data["ssh_public_key_path"]
+    ssh_private_key_path = data.vault_kv_secret_v2.guest_vm.data["ssh_private_key_path"]
   }
 
   # Vault Agent Identity Prep (GitLab Runner SANs)

--- a/terraform/layers/30-infra-gitlab-runner/providers.tf
+++ b/terraform/layers/30-infra-gitlab-runner/providers.tf
@@ -11,7 +11,7 @@ terraform {
 provider "vault" {
   alias        = "production"
   address      = local.sys_vault_addr
-  ca_cert_file = local.state.vault_pki.bootstrap_ca.path
+  ca_cert_file = local.state.vault_pki.bootstrap_ca_b64.path
 
   auth_login {
     path = "auth/approle/login"

--- a/terraform/layers/30-infra-harbor-bootstrapper-frontend/data.tf
+++ b/terraform/layers/30-infra-harbor-bootstrapper-frontend/data.tf
@@ -42,12 +42,14 @@ data "terraform_remote_state" "vault_pki" {
 }
 
 
-data "vault_generic_secret" "guest_vm" {
+data "vault_kv_secret_v2" "guest_vm" {
   provider = vault.production
-  path     = "secret/on-premise-gitlab-deployment/guest_vm"
+  mount    = "secret"
+  name     = "on-premise-gitlab-deployment/guest_vm"
 }
 
-data "vault_generic_secret" "db_vars" {
+data "vault_kv_secret_v2" "db_vars" {
   provider = vault.production
-  path     = "secret/on-premise-gitlab-deployment/harbor-bootstrapper/app"
+  mount    = "secret"
+  name     = "on-premise-gitlab-deployment/harbor-bootstrapper/app"
 }

--- a/terraform/layers/30-infra-harbor-bootstrapper-frontend/locals.tf
+++ b/terraform/layers/30-infra-harbor-bootstrapper-frontend/locals.tf
@@ -52,7 +52,6 @@ locals {
 
 # 3. Security & Credentials Context (sec_ / pki_)
 locals {
-  pki_global_ca  = local.state.metadata.global_vault_pki # PKI Artifacts
   sys_vault_addr = "https://${local.state.vault_sys.service_vip}:443"
 
   # System Level Credentials (OS/SSH)
@@ -73,7 +72,7 @@ locals {
   sec_vault_role_key = local.svc_pki_role.key
   sec_vault_agent_identity = {
     common_name   = local.svc_fqdn
-    ca_cert_b64   = local.state.vault_pki.bootstrap_ca.content
+    ca_cert_b64   = local.state.vault_pki.bootstrap_ca_b64.content_b64
     auth_path     = local.state.vault_pki.workload_identities_approle[local.sec_vault_role_key].auth_path
     role_id       = local.state.vault_pki.workload_identities_approle[local.sec_vault_role_key].role_id
     role_name     = local.state.vault_pki.pki_configuration.pki_roles[local.sec_vault_role_key].name

--- a/terraform/layers/30-infra-harbor-bootstrapper-frontend/locals.tf
+++ b/terraform/layers/30-infra-harbor-bootstrapper-frontend/locals.tf
@@ -56,16 +56,16 @@ locals {
 
   # System Level Credentials (OS/SSH)
   sec_vm_creds = {
-    username             = data.vault_generic_secret.guest_vm.data["vm_username"]
-    password             = data.vault_generic_secret.guest_vm.data["vm_password"]
-    ssh_public_key_path  = data.vault_generic_secret.guest_vm.data["ssh_public_key_path"]
-    ssh_private_key_path = data.vault_generic_secret.guest_vm.data["ssh_private_key_path"]
+    username             = data.vault_kv_secret_v2.guest_vm.data["vm_username"]
+    password             = data.vault_kv_secret_v2.guest_vm.data["vm_password"]
+    ssh_public_key_path  = data.vault_kv_secret_v2.guest_vm.data["ssh_public_key_path"]
+    ssh_private_key_path = data.vault_kv_secret_v2.guest_vm.data["ssh_private_key_path"]
   }
 
   # Service Specific Credentials
   sec_app_creds = {
-    harbor_admin_password = data.vault_generic_secret.db_vars.data["harbor_bootstrapper_admin_password"]
-    harbor_pg_db_password = data.vault_generic_secret.db_vars.data["harbor_bootstrapper_pg_db_password"]
+    harbor_admin_password = data.vault_kv_secret_v2.db_vars.data["harbor_bootstrapper_admin_password"]
+    harbor_pg_db_password = data.vault_kv_secret_v2.db_vars.data["harbor_bootstrapper_pg_db_password"]
   }
 
   # Component Specific Vault Identities

--- a/terraform/layers/30-infra-harbor-bootstrapper-frontend/providers.tf
+++ b/terraform/layers/30-infra-harbor-bootstrapper-frontend/providers.tf
@@ -20,7 +20,7 @@ provider "libvirt" {
 provider "vault" {
   alias        = "production"
   address      = local.sys_vault_addr
-  ca_cert_file = local.state.vault_pki.bootstrap_ca.path
+  ca_cert_file = local.state.vault_pki.bootstrap_ca_b64.path
 
   auth_login {
     path = "auth/approle/login"

--- a/terraform/layers/30-infra-harbor-frontend/data.tf
+++ b/terraform/layers/30-infra-harbor-frontend/data.tf
@@ -42,9 +42,10 @@ data "terraform_remote_state" "vault_pki" {
 }
 
 
-data "vault_generic_secret" "guest_vm" {
+data "vault_kv_secret_v2" "guest_vm" {
   provider = vault.production
-  path     = "secret/on-premise-gitlab-deployment/guest_vm"
+  mount    = "secret"
+  name     = "on-premise-gitlab-deployment/guest_vm"
 }
 
 data "terraform_remote_state" "harbor_bootstrapper" {

--- a/terraform/layers/30-infra-harbor-frontend/locals.tf
+++ b/terraform/layers/30-infra-harbor-frontend/locals.tf
@@ -57,7 +57,7 @@ locals {
     auth_path     = local.state.vault_pki.workload_identities_approle[local.sec_vault_identity_key].auth_path
     role_id       = local.state.vault_pki.workload_identities_approle[local.sec_vault_identity_key].role_id
     role_name     = local.state.vault_pki.pki_configuration.pki_roles[local.sec_vault_identity_key].name
-    ca_cert_b64   = local.state.vault_pki.bootstrap_ca.content
+    ca_cert_b64   = local.state.vault_pki.bootstrap_ca_b64.content_b64
     secret_id     = vault_approle_auth_backend_role_secret_id.microk8s_agent.secret_id
     common_name   = local.svc_fqdn
   }

--- a/terraform/layers/30-infra-harbor-frontend/locals.tf
+++ b/terraform/layers/30-infra-harbor-frontend/locals.tf
@@ -43,10 +43,10 @@ locals {
 
   # System Credentials (OS/SSH)
   sec_system_creds = {
-    username             = data.vault_generic_secret.guest_vm.data["vm_username"]
-    password             = data.vault_generic_secret.guest_vm.data["vm_password"]
-    ssh_public_key_path  = data.vault_generic_secret.guest_vm.data["ssh_public_key_path"]
-    ssh_private_key_path = data.vault_generic_secret.guest_vm.data["ssh_private_key_path"]
+    username             = data.vault_kv_secret_v2.guest_vm.data["vm_username"]
+    password             = data.vault_kv_secret_v2.guest_vm.data["vm_password"]
+    ssh_public_key_path  = data.vault_kv_secret_v2.guest_vm.data["ssh_public_key_path"]
+    ssh_private_key_path = data.vault_kv_secret_v2.guest_vm.data["ssh_private_key_path"]
   }
 
   # Vault Agent Identity Prep (Harbor Frontend SANs)

--- a/terraform/layers/30-infra-harbor-frontend/providers.tf
+++ b/terraform/layers/30-infra-harbor-frontend/providers.tf
@@ -11,7 +11,7 @@ terraform {
 provider "vault" {
   alias        = "production"
   address      = local.sys_vault_addr
-  ca_cert_file = local.state.vault_pki.bootstrap_ca.path
+  ca_cert_file = local.state.vault_pki.bootstrap_ca_b64.path
 
   auth_login {
     path = "auth/approle/login"

--- a/terraform/layers/30-infra-harbor-minio/data.tf
+++ b/terraform/layers/30-infra-harbor-minio/data.tf
@@ -42,12 +42,14 @@ data "terraform_remote_state" "vault_pki" {
 }
 
 
-data "vault_generic_secret" "guest_vm" {
+data "vault_kv_secret_v2" "guest_vm" {
   provider = vault.production
-  path     = "secret/on-premise-gitlab-deployment/guest_vm"
+  mount    = "secret"
+  name     = "on-premise-gitlab-deployment/guest_vm"
 }
 
-data "vault_generic_secret" "db_vars" {
+data "vault_kv_secret_v2" "db_vars" {
   provider = vault.production
-  path     = "secret/on-premise-gitlab-deployment/harbor/databases"
+  mount    = "secret"
+  name     = "on-premise-gitlab-deployment/harbor/databases"
 }

--- a/terraform/layers/30-infra-harbor-minio/locals.tf
+++ b/terraform/layers/30-infra-harbor-minio/locals.tf
@@ -64,17 +64,17 @@ locals {
 
   # System Credentials (OS/SSH)
   sec_system_creds = {
-    username             = data.vault_generic_secret.guest_vm.data["vm_username"]
-    password             = data.vault_generic_secret.guest_vm.data["vm_password"]
-    ssh_public_key_path  = data.vault_generic_secret.guest_vm.data["ssh_public_key_path"]
-    ssh_private_key_path = data.vault_generic_secret.guest_vm.data["ssh_private_key_path"]
+    username             = data.vault_kv_secret_v2.guest_vm.data["vm_username"]
+    password             = data.vault_kv_secret_v2.guest_vm.data["vm_password"]
+    ssh_public_key_path  = data.vault_kv_secret_v2.guest_vm.data["ssh_public_key_path"]
+    ssh_private_key_path = data.vault_kv_secret_v2.guest_vm.data["ssh_private_key_path"]
   }
 
   # Database Credentials (Patroni/Replication)
   sec_db_creds = {
-    minio_root_user     = data.vault_generic_secret.db_vars.data["minio_root_user"]
-    minio_root_password = data.vault_generic_secret.db_vars.data["minio_root_password"]
-    minio_vrrp_secret   = data.vault_generic_secret.db_vars.data["minio_vrrp_secret"]
+    minio_root_user     = data.vault_kv_secret_v2.db_vars.data["minio_root_user"]
+    minio_root_password = data.vault_kv_secret_v2.db_vars.data["minio_root_password"]
+    minio_vrrp_secret   = data.vault_kv_secret_v2.db_vars.data["minio_vrrp_secret"]
   }
 
   # Vault Agent Identity Prep

--- a/terraform/layers/30-infra-harbor-minio/locals.tf
+++ b/terraform/layers/30-infra-harbor-minio/locals.tf
@@ -86,7 +86,7 @@ locals {
     role_id       = local.state.vault_pki.workload_identities_approle[local.sec_vault_identity_key].role_id
     role_name     = local.state.vault_pki.pki_configuration.pki_roles[local.sec_vault_identity_key].name
     secret_id     = vault_approle_auth_backend_role_secret_id.minio_agent.secret_id
-    ca_cert_b64   = local.state.vault_pki.bootstrap_ca.content
+    ca_cert_b64   = local.state.vault_pki.bootstrap_ca_b64.content_b64
     common_name   = local.svc_fqdn
   }
 }

--- a/terraform/layers/30-infra-harbor-minio/providers.tf
+++ b/terraform/layers/30-infra-harbor-minio/providers.tf
@@ -20,7 +20,7 @@ provider "libvirt" {
 provider "vault" {
   alias        = "production"
   address      = local.sys_vault_addr
-  ca_cert_file = local.state.vault_pki.bootstrap_ca.path
+  ca_cert_file = local.state.vault_pki.bootstrap_ca_b64.path
 
   auth_login {
     path = "auth/approle/login"

--- a/terraform/layers/30-infra-harbor-postgres/data.tf
+++ b/terraform/layers/30-infra-harbor-postgres/data.tf
@@ -42,12 +42,14 @@ data "terraform_remote_state" "vault_pki" {
 }
 
 
-data "vault_generic_secret" "guest_vm" {
+data "vault_kv_secret_v2" "guest_vm" {
   provider = vault.production
-  path     = "secret/on-premise-gitlab-deployment/guest_vm"
+  mount    = "secret"
+  name     = "on-premise-gitlab-deployment/guest_vm"
 }
 
-data "vault_generic_secret" "db_vars" {
+data "vault_kv_secret_v2" "db_vars" {
   provider = vault.production
-  path     = "secret/on-premise-gitlab-deployment/harbor/databases"
+  mount    = "secret"
+  name     = "on-premise-gitlab-deployment/harbor/databases"
 }

--- a/terraform/layers/30-infra-harbor-postgres/locals.tf
+++ b/terraform/layers/30-infra-harbor-postgres/locals.tf
@@ -59,17 +59,17 @@ locals {
 
   # System Level Credentials (OS/SSH)
   sec_vm_creds = {
-    username             = data.vault_generic_secret.guest_vm.data["vm_username"]
-    password             = data.vault_generic_secret.guest_vm.data["vm_password"]
-    ssh_public_key_path  = data.vault_generic_secret.guest_vm.data["ssh_public_key_path"]
-    ssh_private_key_path = data.vault_generic_secret.guest_vm.data["ssh_private_key_path"]
+    username             = data.vault_kv_secret_v2.guest_vm.data["vm_username"]
+    password             = data.vault_kv_secret_v2.guest_vm.data["vm_password"]
+    ssh_public_key_path  = data.vault_kv_secret_v2.guest_vm.data["ssh_public_key_path"]
+    ssh_private_key_path = data.vault_kv_secret_v2.guest_vm.data["ssh_private_key_path"]
   }
 
   # Service Specific Credentials (DB/PG)
   sec_app_creds = {
-    replication_password = data.vault_generic_secret.db_vars.data["pg_replication_password"]
-    superuser_password   = data.vault_generic_secret.db_vars.data["pg_superuser_password"]
-    vrrp_secret          = data.vault_generic_secret.db_vars.data["pg_vrrp_secret"]
+    replication_password = data.vault_kv_secret_v2.db_vars.data["pg_replication_password"]
+    superuser_password   = data.vault_kv_secret_v2.db_vars.data["pg_superuser_password"]
+    vrrp_secret          = data.vault_kv_secret_v2.db_vars.data["pg_vrrp_secret"]
   }
 
   # Component Specific Vault Identities

--- a/terraform/layers/30-infra-harbor-postgres/locals.tf
+++ b/terraform/layers/30-infra-harbor-postgres/locals.tf
@@ -80,7 +80,7 @@ locals {
     role_id       = local.state.vault_pki.workload_identities_approle[local.sec_vault_role_key].role_id
     role_name     = local.state.vault_pki.pki_configuration.pki_roles[local.sec_vault_role_key].name
     secret_id     = vault_approle_auth_backend_role_secret_id.postgres_agent.secret_id
-    ca_cert_b64   = local.state.vault_pki.bootstrap_ca.content
+    ca_cert_b64   = local.state.vault_pki.bootstrap_ca_b64.content_b64
     common_name   = local.svc_fqdn
   }
 }

--- a/terraform/layers/30-infra-harbor-postgres/providers.tf
+++ b/terraform/layers/30-infra-harbor-postgres/providers.tf
@@ -20,7 +20,7 @@ provider "libvirt" {
 provider "vault" {
   alias        = "production"
   address      = local.sys_vault_addr
-  ca_cert_file = local.state.vault_pki.bootstrap_ca.path
+  ca_cert_file = local.state.vault_pki.bootstrap_ca_b64.path
 
   auth_login {
     path = "auth/approle/login"

--- a/terraform/layers/30-infra-harbor-redis/data.tf
+++ b/terraform/layers/30-infra-harbor-redis/data.tf
@@ -42,12 +42,14 @@ data "terraform_remote_state" "vault_pki" {
 }
 
 
-data "vault_generic_secret" "guest_vm" {
+data "vault_kv_secret_v2" "guest_vm" {
   provider = vault.production
-  path     = "secret/on-premise-gitlab-deployment/guest_vm"
+  mount    = "secret"
+  name     = "on-premise-gitlab-deployment/guest_vm"
 }
 
-data "vault_generic_secret" "db_vars" {
+data "vault_kv_secret_v2" "db_vars" {
   provider = vault.production
-  path     = "secret/on-premise-gitlab-deployment/harbor/databases"
+  mount    = "secret"
+  name     = "on-premise-gitlab-deployment/harbor/databases"
 }

--- a/terraform/layers/30-infra-harbor-redis/locals.tf
+++ b/terraform/layers/30-infra-harbor-redis/locals.tf
@@ -80,7 +80,7 @@ locals {
     role_id       = local.state.vault_pki.workload_identities_approle[local.sec_vault_role_key].role_id
     role_name     = local.state.vault_pki.pki_configuration.pki_roles[local.sec_vault_role_key].name
     secret_id     = vault_approle_auth_backend_role_secret_id.redis_agent.secret_id
-    ca_cert_b64   = local.state.vault_pki.bootstrap_ca.content
+    ca_cert_b64   = local.state.vault_pki.bootstrap_ca_b64.content_b64
     common_name   = local.svc_fqdn
   }
 }

--- a/terraform/layers/30-infra-harbor-redis/locals.tf
+++ b/terraform/layers/30-infra-harbor-redis/locals.tf
@@ -59,17 +59,17 @@ locals {
 
   # System Level Credentials (OS/SSH)
   sec_vm_creds = {
-    username             = data.vault_generic_secret.guest_vm.data["vm_username"]
-    password             = data.vault_generic_secret.guest_vm.data["vm_password"]
-    ssh_public_key_path  = data.vault_generic_secret.guest_vm.data["ssh_public_key_path"]
-    ssh_private_key_path = data.vault_generic_secret.guest_vm.data["ssh_private_key_path"]
+    username             = data.vault_kv_secret_v2.guest_vm.data["vm_username"]
+    password             = data.vault_kv_secret_v2.guest_vm.data["vm_password"]
+    ssh_public_key_path  = data.vault_kv_secret_v2.guest_vm.data["ssh_public_key_path"]
+    ssh_private_key_path = data.vault_kv_secret_v2.guest_vm.data["ssh_private_key_path"]
   }
 
   # Service Specific Credentials
   sec_app_creds = {
-    masterauth  = data.vault_generic_secret.db_vars.data["redis_masterauth"]
-    requirepass = data.vault_generic_secret.db_vars.data["redis_requirepass"]
-    vrrp_secret = data.vault_generic_secret.db_vars.data["redis_vrrp_secret"]
+    masterauth  = data.vault_kv_secret_v2.db_vars.data["redis_masterauth"]
+    requirepass = data.vault_kv_secret_v2.db_vars.data["redis_requirepass"]
+    vrrp_secret = data.vault_kv_secret_v2.db_vars.data["redis_vrrp_secret"]
   }
 
   # Component Specific Vault Identities

--- a/terraform/layers/30-infra-harbor-redis/providers.tf
+++ b/terraform/layers/30-infra-harbor-redis/providers.tf
@@ -20,7 +20,7 @@ provider "libvirt" {
 provider "vault" {
   alias        = "production"
   address      = local.sys_vault_addr
-  ca_cert_file = local.state.vault_pki.bootstrap_ca.path
+  ca_cert_file = local.state.vault_pki.bootstrap_ca_b64.path
 
   auth_login {
     path = "auth/approle/login"

--- a/terraform/layers/40-provision-gitlab-databases/outputs.tf
+++ b/terraform/layers/40-provision-gitlab-databases/outputs.tf
@@ -28,12 +28,12 @@ output "postgres_connection_info" {
   sensitive = true
 }
 
-output "postgres_client_cert" {
+output "postgres_client_cert_b64" {
   description = "Postgres client certificate for Layer 50 credentials"
   value = {
-    crt = base64encode(vault_pki_secret_backend_cert.gitlab_db_client.certificate)
-    key = base64encode(vault_pki_secret_backend_cert.gitlab_db_client.private_key)
-    ca  = base64encode(vault_pki_secret_backend_cert.gitlab_db_client.ca_chain)
+    crt_b64 = base64encode(vault_pki_secret_backend_cert.gitlab_db_client.certificate)
+    key_b64 = base64encode(vault_pki_secret_backend_cert.gitlab_db_client.private_key)
+    ca_b64  = base64encode(vault_pki_secret_backend_cert.gitlab_db_client.ca_chain)
   }
   sensitive = true
 }

--- a/terraform/layers/40-provision-gitlab-databases/providers.tf
+++ b/terraform/layers/40-provision-gitlab-databases/providers.tf
@@ -20,7 +20,7 @@ terraform {
 provider "vault" {
   alias        = "production"
   address      = local.vault_address
-  ca_cert_file = local.state.vault_pki.bootstrap_ca.path
+  ca_cert_file = local.state.vault_pki.bootstrap_ca_b64.path
 
   auth_login {
     path = "auth/approle/login"
@@ -38,7 +38,7 @@ provider "minio" {
   minio_password    = data.vault_kv_secret_v2.db_vars.data["minio_root_password"]
   minio_ssl         = true
   minio_insecure    = false
-  minio_cacert_file = local.state.vault_pki.bootstrap_ca.path
+  minio_cacert_file = local.state.vault_pki.bootstrap_ca_b64.path
 }
 
 provider "postgresql" {

--- a/terraform/layers/40-provision-harbor-bootstrapper-frontend/providers.tf
+++ b/terraform/layers/40-provision-harbor-bootstrapper-frontend/providers.tf
@@ -17,7 +17,7 @@ terraform {
 provider "vault" {
   alias        = "production"
   address      = local.sys_vault_addr
-  ca_cert_file = local.state.vault_pki.bootstrap_ca.path
+  ca_cert_file = local.state.vault_pki.bootstrap_ca_b64.path
 
   auth_login {
     path = "auth/approle/login"

--- a/terraform/layers/40-provision-harbor-databases/providers.tf
+++ b/terraform/layers/40-provision-harbor-databases/providers.tf
@@ -20,7 +20,7 @@ terraform {
 provider "vault" {
   alias        = "production"
   address      = local.vault_address
-  ca_cert_file = local.state.vault_pki.bootstrap_ca.path
+  ca_cert_file = local.state.vault_pki.bootstrap_ca_b64.path
 
   auth_login {
     path = "auth/approle/login"
@@ -38,7 +38,7 @@ provider "minio" {
   minio_password    = data.vault_kv_secret_v2.db_vars.data["minio_root_password"]
   minio_ssl         = true
   minio_insecure    = false
-  minio_cacert_file = local.state.vault_pki.bootstrap_ca.path
+  minio_cacert_file = local.state.vault_pki.bootstrap_ca_b64.path
 }
 
 provider "postgresql" {

--- a/terraform/layers/50-platform-gitlab-runner/locals.tf
+++ b/terraform/layers/50-platform-gitlab-runner/locals.tf
@@ -57,7 +57,7 @@ locals {
   # Vault Connection (Standardized)
   vault_api_port = local.state.metadata.global_topology_network["vault"]["frontend"].ports["api"].frontend_port
   vault_address  = "https://${local.state.vault_pki.vault_service_vip}:${local.vault_api_port}"
-  vault_ca_cert  = local.state.vault_pki.bootstrap_ca.content
+  vault_ca_cert  = base64decode(local.state.vault_pki.bootstrap_ca_b64.content_b64)
   vault_pki_path = local.state.vault_pki.pki_configuration.path
 
   # Map to the specific component identity in Vault PKI
@@ -72,7 +72,7 @@ locals {
   ca_bundle_config = {
     name        = "gitlab-ca-bundle" # K8s Secret Name
     secret_name = "gitlab-ca-bundle" # Helm Chart Reference Name
-    content     = base64decode(local.state.vault_pki.pki_configuration.ca_cert)
+    content     = base64decode(local.state.vault_pki.pki_configuration.ca_cert_b64)
   }
 
   # 6. DNS Configuration (Standardized Alignment)

--- a/terraform/layers/50-platform-gitlab-runner/providers.tf
+++ b/terraform/layers/50-platform-gitlab-runner/providers.tf
@@ -23,7 +23,7 @@ terraform {
 provider "vault" {
   alias        = "production"
   address      = local.vault_address
-  ca_cert_file = local.state.vault_pki.bootstrap_ca.path
+  ca_cert_file = local.state.vault_pki.bootstrap_ca_b64.path
 
   auth_login {
     path = "auth/approle/login"

--- a/terraform/layers/50-platform-gitlab/data.tf
+++ b/terraform/layers/50-platform-gitlab/data.tf
@@ -68,9 +68,10 @@ data "terraform_remote_state" "harbor_bootstrapper" {
 }
 
 # Harbor Bootstrapper Admin Credentials (for Helm OCI Registry)
-data "vault_generic_secret" "harbor_bootstrapper" {
+data "vault_kv_secret_v2" "harbor_bootstrapper" {
   provider = vault.production
-  path     = "secret/on-premise-gitlab-deployment/harbor-bootstrapper/app"
+  mount    = "secret"
+  name     = "on-premise-gitlab-deployment/harbor-bootstrapper/app"
 }
 
 # 1. Database Provisioning State
@@ -82,9 +83,10 @@ data "terraform_remote_state" "provision_databases" {
 }
 
 # 2. Fetch Kubeconfig from Production Vault
-data "vault_generic_secret" "kubeconfig" {
+data "vault_kv_secret_v2" "kubeconfig" {
   provider = vault.production
-  path     = "secret/on-premise-gitlab-deployment/infrastructure/kubeconfig/gitlab"
+  mount    = "secret"
+  name     = "on-premise-gitlab-deployment/infrastructure/kubeconfig/gitlab"
 }
 
 # Fetch the Cluster CA

--- a/terraform/layers/50-platform-gitlab/locals.tf
+++ b/terraform/layers/50-platform-gitlab/locals.tf
@@ -17,7 +17,7 @@ locals {
 
 # 2. K8s Provider Authentication Context
 locals {
-  kubeconfig   = yamldecode(base64decode(data.vault_generic_secret.kubeconfig.data["content_b64"]))
+  kubeconfig   = yamldecode(base64decode(data.vault_kv_secret_v2.kubeconfig.data["content_b64"]))
   cluster_info = local.kubeconfig.clusters[0].cluster
   user_info    = local.kubeconfig.users[0].user
 

--- a/terraform/layers/50-platform-gitlab/locals.tf
+++ b/terraform/layers/50-platform-gitlab/locals.tf
@@ -74,7 +74,7 @@ locals {
   # Vault Connection (Standardized)
   vault_api_port          = local.state.metadata.global_topology_network["vault"]["frontend"].ports["api"].frontend_port
   vault_address           = "https://${local.state.vault_pki.vault_service_vip}:${local.vault_api_port}"
-  vault_ca_cert           = local.state.vault_pki.bootstrap_ca.content
+  vault_ca_cert           = base64decode(local.state.vault_pki.bootstrap_ca_b64.content_b64)
   vault_pki_path          = local.state.vault_pki.pki_configuration.path
   vault_pki_lease_default = local.state.vault_pki.pki_configuration.lease_durations.default
   vault_pki_lease_agent   = local.state.vault_pki.pki_configuration.lease_durations.agent
@@ -136,7 +136,7 @@ locals {
     secret_name = "gitlab-ca-bundle" # Helm Chart Reference Name
 
     # Use the current active CA from Vault PKI directly
-    content = base64decode(local.state.vault_pki.pki_configuration.ca_cert)
+    content = base64decode(local.state.vault_pki.pki_configuration.ca_cert_b64)
   }
 }
 

--- a/terraform/layers/50-platform-gitlab/providers.tf
+++ b/terraform/layers/50-platform-gitlab/providers.tf
@@ -28,7 +28,7 @@ terraform {
 provider "vault" {
   alias        = "production"
   address      = local.vault_address
-  ca_cert_file = local.state.vault_pki.bootstrap_ca.path
+  ca_cert_file = local.state.vault_pki.bootstrap_ca_b64.path
 
   auth_login {
     path = "auth/approle/login"

--- a/terraform/layers/50-platform-gitlab/resources-gitlab-secrets.tf
+++ b/terraform/layers/50-platform-gitlab/resources-gitlab-secrets.tf
@@ -22,9 +22,9 @@ resource "vault_kv_secret_v2" "gitlab_db_keys" {
 
     # TLS Context for the application
     tls = {
-      crt = local.state.provision_databases.postgres_client_cert.crt
-      key = local.state.provision_databases.postgres_client_cert.key
-      ca  = local.state.provision_databases.postgres_client_cert.ca
+      crt = local.state.provision_databases.postgres_client_cert_b64.crt_b64
+      key = local.state.provision_databases.postgres_client_cert_b64.key_b64
+      ca  = local.state.provision_databases.postgres_client_cert_b64.ca_b64
     }
   })
 }

--- a/terraform/layers/50-platform-harbor/locals.tf
+++ b/terraform/layers/50-platform-harbor/locals.tf
@@ -55,7 +55,7 @@ locals {
   # Vault Connection
   vault_api_port = local.state.metadata.global_topology_network["vault"]["frontend"].ports["api"].frontend_port
   vault_address  = "https://${local.state.vault_pki.vault_service_vip}:${local.vault_api_port}"
-  vault_ca_cert  = local.state.vault_pki.bootstrap_ca.content
+  vault_ca_cert  = base64decode(local.state.vault_pki.bootstrap_ca_b64.content_b64)
   vault_pki_path = local.state.vault_pki.pki_configuration.path
 
   # Dependency Ports
@@ -83,7 +83,7 @@ locals {
   ca_bundle_config = {
     name        = "harbor-ca-bundle" # K8s Secret Name
     secret_name = "harbor-ca-bundle" # Helm Chart Reference Name
-    content     = base64decode(local.state.vault_pki.pki_configuration.ca_cert)
+    content     = base64decode(local.state.vault_pki.pki_configuration.ca_cert_b64)
   }
 }
 

--- a/terraform/layers/50-platform-harbor/providers.tf
+++ b/terraform/layers/50-platform-harbor/providers.tf
@@ -28,7 +28,7 @@ terraform {
 provider "vault" {
   alias        = "production"
   address      = local.vault_address
-  ca_cert_file = local.state.vault_pki.bootstrap_ca.path
+  ca_cert_file = local.state.vault_pki.bootstrap_ca_b64.path
 
   auth_login {
     path = "auth/approle/login"

--- a/terraform/layers/60-provision-gitlab/providers.tf
+++ b/terraform/layers/60-provision-gitlab/providers.tf
@@ -16,7 +16,7 @@ terraform {
 provider "vault" {
   alias        = "production"
   address      = local.vault_address
-  ca_cert_file = local.state.vault_pki.bootstrap_ca.path
+  ca_cert_file = local.state.vault_pki.bootstrap_ca_b64.path
 
   auth_login {
     path = "auth/approle/login"

--- a/terraform/layers/60-provision-harbor/providers.tf
+++ b/terraform/layers/60-provision-harbor/providers.tf
@@ -16,7 +16,7 @@ terraform {
 provider "vault" {
   alias        = "production"
   address      = local.vault_address
-  ca_cert_file = local.state.vault_pki.bootstrap_ca.path
+  ca_cert_file = local.state.vault_pki.bootstrap_ca_b64.path
 
   auth_login {
     path = "auth/approle/login"

--- a/terraform/middleware/ha-service-kvm-central-lb/locals.tf
+++ b/terraform/middleware/ha-service-kvm-central-lb/locals.tf
@@ -197,9 +197,9 @@ locals {
       haproxy_stats_pass   = local.credentials_haproxy_for_ansible.haproxy_stats_pass
       keepalived_auth_pass = local.credentials_haproxy_for_ansible.keepalived_auth_pass
     },
-    var.security_pki_bundle != null ? {
-      vault_haproxy_bundle = var.security_pki_bundle.haproxy_bundle
-      vault_ca_cert        = var.security_pki_bundle.ca_cert
+    var.security_pki_bundle_b64 != null ? {
+      vault_haproxy_bundle_b64 = var.security_pki_bundle_b64.haproxy_bundle_b64
+      vault_ca_cert_b64        = var.security_pki_bundle_b64.ca_cert_b64
     } : {}
   )
 }

--- a/terraform/middleware/ha-service-kvm-central-lb/variables.tf
+++ b/terraform/middleware/ha-service-kvm-central-lb/variables.tf
@@ -82,7 +82,7 @@ variable "network_service_segments" {
   }))
 }
 
-variable "security_pki_bundle" {
+variable "security_pki_bundle_b64" {
   description = "PKI certificates passed from Layer 00 via Layer 05"
   type        = any
   default     = null

--- a/terraform/middleware/ha-service-kvm-general/locals.tf
+++ b/terraform/middleware/ha-service-kvm-general/locals.tf
@@ -121,10 +121,10 @@ locals {
     vault_auth_path         = var.security_vault_agent_identity.auth_path
   } : {}
 
-  ansible_extra_vars_pki = var.security_pki_bundle != null && length(keys(var.security_pki_bundle)) > 0 ? {
-    vault_server_cert = var.security_pki_bundle.server_cert
-    vault_server_key  = var.security_pki_bundle.server_key
-    vault_ca_cert     = var.security_pki_bundle.ca_cert
+  ansible_extra_vars_pki = var.security_pki_bundle_b64 != null && length(keys(var.security_pki_bundle_b64)) > 0 ? {
+    vault_server_cert_b64 = var.security_pki_bundle_b64.server_cert_b64
+    vault_server_key_b64  = var.security_pki_bundle_b64.server_key_b64
+    vault_ca_cert_b64     = var.security_pki_bundle_b64.ca_cert_b64
   } : {}
 
   ansible_extra_vars = merge(

--- a/terraform/middleware/ha-service-kvm-general/variables.tf
+++ b/terraform/middleware/ha-service-kvm-general/variables.tf
@@ -118,7 +118,7 @@ variable "security_vault_agent_identity" {
 }
 
 
-variable "security_pki_bundle" {
+variable "security_pki_bundle_b64" {
   description = "PKI artifacts passed from vault_pki."
   type        = any
   default     = null

--- a/terraform/modules/configuration/vault-pki-setup/outputs.tf
+++ b/terraform/modules/configuration/vault-pki-setup/outputs.tf
@@ -4,9 +4,9 @@ output "vault_pki_path" {
   value       = vault_mount.pki_prod.path
 }
 
-output "pki_root_ca_certificate" {
+output "pki_root_ca_certificate_b64" {
   description = "The root CA certificate of the PKI engine"
-  value       = vault_pki_secret_backend_root_cert.prod_root_ca.certificate
+  value       = base64encode(vault_pki_secret_backend_root_cert.prod_root_ca.certificate)
 }
 
 output "pki_roles" {

--- a/terraform/modules/kubernetes-addons/platform-trust-engine/resources.tf
+++ b/terraform/modules/kubernetes-addons/platform-trust-engine/resources.tf
@@ -116,7 +116,7 @@ resource "kubectl_manifest" "cluster_issuer" {
       vault = {
         path     = "${var.issuer_config.pki_mount_path}/${var.issuer_config.issue_path}/${var.issuer_config.vault_role_name}"
         server   = var.vault_config.address
-        caBundle = var.vault_config.ca_cert
+        caBundle = base64encode(var.vault_config.ca_cert)
 
         auth = {
           kubernetes = {


### PR DESCRIPTION
## Summary

The primary objective of this PR is the establishment of a consistent PKI data transmission standard across the entire environment. Enforcement of the `_b64` suffix in variable and output names eliminates ambiguity between raw PEM strings and Base64 encoded data. This prevents mTLS trust chain failures caused by double-encoding or decoding errors.

All `vault_generic_secret` declarations within the project are migrated to `vault_kv_secret_v2` concurrently.

### Verification

- [x] **Idempotency**: Re-execution of `terraform apply` confirms that the status across all layers remains consistent.