### PR TITLE
feat(kubernetes/reloader): Deploy `reloader` to Automate Pod Rollouts for GitLab and Harbor Infrastructure

### DIFF
--- a/ansible/roles/40-provision-harbor-bootstrapper/defaults/main.yaml
+++ b/ansible/roles/40-provision-harbor-bootstrapper/defaults/main.yaml
@@ -40,6 +40,11 @@ helm_charts_to_sync: # List of Helm Charts to Synchronize
     repo: "https://helm.goharbor.io"
     is_oci: false
 
+  - name: "reloader"
+    version: "2.2.11"
+    repo: "https://stakater.github.io/stakater-charts"
+    is_oci: false
+
   - name: "gitlab-runner"
     version: "0.85.0"
     repo: "https://charts.gitlab.io/"

--- a/terraform/layers/50-platform-gitlab-frontend/locals.tf
+++ b/terraform/layers/50-platform-gitlab-frontend/locals.tf
@@ -152,24 +152,20 @@ locals {
     repository = "oci://${local.harbor_registry}/${local.helm_chart_project}"
   }
 
+  # Internal helper for reloader annotations to avoid duplication across components
+  _gitlab_reloader_common = {
+    deployment = {
+      annotations = {
+        "reloader.stakater.com/auto"          = "true"
+        "secret.reloader.stakater.com/reload" = "gitlab-postgres-tls"
+      }
+    }
+  }
+
   gitlab_reloader_annotations = {
     gitlab = {
-      webservice = {
-        deployment = {
-          annotations = {
-            "reloader.stakater.com/auto" = "true"
-            "secret.reloader.stakater.com/reload" = "gitlab-postgres-tls"
-          }
-        }
-      }
-      sidekiq = {
-        deployment = {
-          annotations = {
-            "reloader.stakater.com/auto" = "true"
-            "secret.reloader.stakater.com/reload" = "gitlab-postgres-tls"
-          }
-        }
-      }
+      webservice = local._gitlab_reloader_common
+      sidekiq    = local._gitlab_reloader_common
     }
   }
 }

--- a/terraform/layers/50-platform-gitlab-frontend/locals.tf
+++ b/terraform/layers/50-platform-gitlab-frontend/locals.tf
@@ -155,13 +155,19 @@ locals {
   gitlab_reloader_annotations = {
     gitlab = {
       webservice = {
-        annotations = {
-          "reloader.stakater.com/auto" = "true"
+        deployment = {
+          annotations = {
+            "reloader.stakater.com/auto" = "true"
+            "secret.reloader.stakater.com/reload" = "gitlab-postgres-tls"
+          }
         }
       }
       sidekiq = {
-        annotations = {
-          "reloader.stakater.com/auto" = "true"
+        deployment = {
+          annotations = {
+            "reloader.stakater.com/auto" = "true"
+            "secret.reloader.stakater.com/reload" = "gitlab-postgres-tls"
+          }
         }
       }
     }

--- a/terraform/layers/50-platform-gitlab-frontend/locals.tf
+++ b/terraform/layers/50-platform-gitlab-frontend/locals.tf
@@ -145,3 +145,25 @@ locals {
   s3_region          = "us-east-1"
   minio_function_map = local.state.provision_databases.minio_function_map
 }
+
+# 8. Addons Configuration (Reloader)
+locals {
+  reloader_oci_config = {
+    repository = "oci://${local.harbor_registry}/${local.helm_chart_project}"
+  }
+
+  gitlab_reloader_annotations = {
+    gitlab = {
+      webservice = {
+        annotations = {
+          "reloader.stakater.com/auto" = "true"
+        }
+      }
+      sidekiq = {
+        annotations = {
+          "reloader.stakater.com/auto" = "true"
+        }
+      }
+    }
+  }
+}

--- a/terraform/layers/50-platform-gitlab-frontend/locals.tf
+++ b/terraform/layers/50-platform-gitlab-frontend/locals.tf
@@ -69,7 +69,8 @@ locals {
   api_endpoint = "https://${local.state.kubeadm.service_vip}:${local.api_port}"
 
   # Cluster CA from ConfigMap
-  cluster_ca = data.kubernetes_config_map.kube_root_ca.data["ca.crt"]
+  cluster_ca  = data.kubernetes_config_map.kube_root_ca.data["ca.crt"]
+  postgres_ca = "gitlab-postgres-tls"
 
   # Vault Connection (Standardized)
   vault_api_port          = local.state.metadata.global_topology_network["vault"]["frontend"].ports["api"].frontend_port
@@ -157,7 +158,7 @@ locals {
     deployment = {
       annotations = {
         "reloader.stakater.com/auto"          = "true"
-        "secret.reloader.stakater.com/reload" = "gitlab-postgres-tls"
+        "secret.reloader.stakater.com/reload" = local.postgres_ca
       }
     }
   }

--- a/terraform/layers/50-platform-gitlab-frontend/main.tf
+++ b/terraform/layers/50-platform-gitlab-frontend/main.tf
@@ -59,7 +59,7 @@ module "platform_mtls_certificate" {
   source     = "../../modules/kubernetes-addons/platform-mtls-certificate"
   depends_on = [module.platform_trust_engine]
 
-  name         = "gitlab-postgres-tls"
+  name         = local.postgres_ca
   namespace    = kubernetes_namespace.gitlab_ns.metadata[0].name
   common_name  = local.fqdn_gitlab
   issuer_name  = var.trust_engine_config.issuer_name
@@ -138,7 +138,7 @@ module "coredns_config" {
 }
 
 module "reloader" {
-  source = "../../modules/kubernetes-addons/reloader"
+  source            = "../../modules/kubernetes-addons/reloader"
   harbor_oci_config = local.reloader_oci_config
 }
 

--- a/terraform/layers/50-platform-gitlab-frontend/main.tf
+++ b/terraform/layers/50-platform-gitlab-frontend/main.tf
@@ -137,6 +137,13 @@ module "coredns_config" {
   hosts = local.dns_hosts
 }
 
+module "reloader" {
+  source = "../../modules/kubernetes-addons/reloader"
+  harbor_oci_config = {
+    repository = "oci://${local.harbor_registry}/${local.helm_chart_project}"
+  }
+}
+
 resource "kubernetes_namespace" "gitlab_ns" {
   metadata {
     name = var.gitlab_helm_config.namespace
@@ -150,7 +157,8 @@ module "gitlab_core" {
     kubernetes_namespace.gitlab_ns,
     module.coredns_config,
     module.platform_trust_engine,
-    module.ingress_nginx
+    module.ingress_nginx,
+    module.reloader
   ]
 
   # Helm Deployment Configuration
@@ -160,6 +168,22 @@ module "gitlab_core" {
     timeout        = 1500
     image_registry = local.harbor_registry
     chart_project  = local.helm_chart_project
+  }
+
+  # HCL declaration for Reloader annotations
+  helm_values_override = {
+    gitlab = {
+      webservice = {
+        annotations = {
+          "reloader.stakater.com/auto" = "true"
+        }
+      }
+      sidekiq = {
+        annotations = {
+          "reloader.stakater.com/auto" = "true"
+        }
+      }
+    }
   }
 
   # GitLab Application Configuration

--- a/terraform/layers/50-platform-gitlab-frontend/main.tf
+++ b/terraform/layers/50-platform-gitlab-frontend/main.tf
@@ -139,9 +139,7 @@ module "coredns_config" {
 
 module "reloader" {
   source = "../../modules/kubernetes-addons/reloader"
-  harbor_oci_config = {
-    repository = "oci://${local.harbor_registry}/${local.helm_chart_project}"
-  }
+  harbor_oci_config = local.reloader_oci_config
 }
 
 resource "kubernetes_namespace" "gitlab_ns" {
@@ -171,20 +169,7 @@ module "gitlab_core" {
   }
 
   # HCL declaration for Reloader annotations
-  helm_values_override = {
-    gitlab = {
-      webservice = {
-        annotations = {
-          "reloader.stakater.com/auto" = "true"
-        }
-      }
-      sidekiq = {
-        annotations = {
-          "reloader.stakater.com/auto" = "true"
-        }
-      }
-    }
-  }
+  helm_values_override = local.gitlab_reloader_annotations
 
   # GitLab Application Configuration
   gitlab_config = {

--- a/terraform/layers/50-platform-gitlab-frontend/outputs.tf
+++ b/terraform/layers/50-platform-gitlab-frontend/outputs.tf
@@ -23,3 +23,13 @@ output "cert_manager_info" {
     issuer_name = module.platform_trust_engine.issuer_name
   }
 }
+
+output "gitlab_helm_metadata" {
+  description = "Detailed metadata of the deployed GitLab Helm release"
+  value       = module.gitlab_core.helm_release_metadata
+}
+
+output "reloader_helm_metadata" {
+  description = "Detailed metadata of the deployed Reloader Helm release"
+  value       = module.reloader.helm_release_metadata
+}

--- a/terraform/layers/50-platform-harbor-frontend/locals.tf
+++ b/terraform/layers/50-platform-harbor-frontend/locals.tf
@@ -124,8 +124,7 @@ locals {
   # Internal helper for reloader annotations to avoid duplication across components
   _harbor_reloader_common = {
     podAnnotations = {
-      "reloader.stakater.com/auto"          = "true"
-      "secret.reloader.stakater.com/reload" = "harbor-ingress-cert,harbor-ca-bundle"
+      "secret.reloader.stakater.com/reload" = local.ca_bundle_config.name
     }
   }
 

--- a/terraform/layers/50-platform-harbor-frontend/locals.tf
+++ b/terraform/layers/50-platform-harbor-frontend/locals.tf
@@ -123,7 +123,7 @@ locals {
 
   # Internal helper for reloader annotations to avoid duplication across components
   _harbor_reloader_common = {
-    deploymentAnnotations = {
+    podAnnotations = {
       "reloader.stakater.com/auto"          = "true"
       "secret.reloader.stakater.com/reload" = "harbor-ingress-cert,harbor-ca-bundle"
     }

--- a/terraform/layers/50-platform-harbor-frontend/locals.tf
+++ b/terraform/layers/50-platform-harbor-frontend/locals.tf
@@ -125,11 +125,19 @@ locals {
     core = {
       podAnnotations = {
         "reloader.stakater.com/auto" = "true"
+        "secret.reloader.stakater.com/reload" = "harbor-ingress-cert,harbor-ca-bundle"
       }
     }
     jobservice = {
       podAnnotations = {
         "reloader.stakater.com/auto" = "true"
+        "secret.reloader.stakater.com/reload" = "harbor-ingress-cert,harbor-ca-bundle"
+      }
+    }
+    registry = {
+      podAnnotations = {
+        "reloader.stakater.com/auto" = "true"
+        "secret.reloader.stakater.com/reload" = "harbor-ingress-cert,harbor-ca-bundle"
       }
     }
   }

--- a/terraform/layers/50-platform-harbor-frontend/locals.tf
+++ b/terraform/layers/50-platform-harbor-frontend/locals.tf
@@ -121,24 +121,17 @@ locals {
     repository = "oci://${local.harbor_registry}/${local.helm_chart_project}"
   }
 
+  # Internal helper for reloader annotations to avoid duplication across components
+  _harbor_reloader_common = {
+    deploymentAnnotations = {
+      "reloader.stakater.com/auto"          = "true"
+      "secret.reloader.stakater.com/reload" = "harbor-ingress-cert,harbor-ca-bundle"
+    }
+  }
+
   harbor_reloader_annotations = {
-    core = {
-      podAnnotations = {
-        "reloader.stakater.com/auto" = "true"
-        "secret.reloader.stakater.com/reload" = "harbor-ingress-cert,harbor-ca-bundle"
-      }
-    }
-    jobservice = {
-      podAnnotations = {
-        "reloader.stakater.com/auto" = "true"
-        "secret.reloader.stakater.com/reload" = "harbor-ingress-cert,harbor-ca-bundle"
-      }
-    }
-    registry = {
-      podAnnotations = {
-        "reloader.stakater.com/auto" = "true"
-        "secret.reloader.stakater.com/reload" = "harbor-ingress-cert,harbor-ca-bundle"
-      }
-    }
+    core       = local._harbor_reloader_common
+    jobservice = local._harbor_reloader_common
+    registry   = local._harbor_reloader_common
   }
 }

--- a/terraform/layers/50-platform-harbor-frontend/locals.tf
+++ b/terraform/layers/50-platform-harbor-frontend/locals.tf
@@ -114,3 +114,23 @@ locals {
     "${local.state.harbor_bootstrapper.service_vip}" = local.harbor_registry
   }
 }
+
+# 7. Addons Configuration (Reloader)
+locals {
+  reloader_oci_config = {
+    repository = "oci://${local.harbor_registry}/${local.helm_chart_project}"
+  }
+
+  harbor_reloader_annotations = {
+    core = {
+      podAnnotations = {
+        "reloader.stakater.com/auto" = "true"
+      }
+    }
+    jobservice = {
+      podAnnotations = {
+        "reloader.stakater.com/auto" = "true"
+      }
+    }
+  }
+}

--- a/terraform/layers/50-platform-harbor-frontend/main.tf
+++ b/terraform/layers/50-platform-harbor-frontend/main.tf
@@ -21,10 +21,10 @@ module "platform_trust_engine" {
 
   # 3. Issuer Configuration (The "Contract" between K8s and Vault)
   issuer_config = {
-    name             = var.trust_engine_config.issuer_name
-    issue_path       = "sign"
-    vault_role_name  = local.vault_role_name
-    pki_mount_path   = local.vault_pki_path
+    name            = var.trust_engine_config.issuer_name
+    issue_path      = "sign"
+    vault_role_name = local.vault_role_name
+    pki_mount_path  = local.vault_pki_path
   }
 
   # 4. Reviewer Identity (The entity that validates tokens)
@@ -60,6 +60,13 @@ module "coredns_config" {
   source = "../../modules/kubernetes-addons/coredns-config"
 
   hosts = local.dns_hosts
+}
+
+module "reloader" {
+  source = "../../modules/kubernetes-addons/reloader"
+  harbor_oci_config = {
+    repository = "oci://${local.harbor_registry}/${local.helm_chart_project}"
+  }
 }
 
 resource "kubernetes_namespace" "harbor" {
@@ -127,5 +134,21 @@ module "harbor_core" {
     }
   }
 
-  depends_on = [module.platform_trust_engine]
+  helm_values_override = {
+    core = {
+      podAnnotations = {
+        "reloader.stakater.com/auto" = "true"
+      }
+    }
+    jobservice = {
+      podAnnotations = {
+        "reloader.stakater.com/auto" = "true"
+      }
+    }
+  }
+
+  depends_on = [
+    module.platform_trust_engine,
+    module.reloader
+  ]
 }

--- a/terraform/layers/50-platform-harbor-frontend/main.tf
+++ b/terraform/layers/50-platform-harbor-frontend/main.tf
@@ -63,10 +63,8 @@ module "coredns_config" {
 }
 
 module "reloader" {
-  source = "../../modules/kubernetes-addons/reloader"
-  harbor_oci_config = {
-    repository = "oci://${local.harbor_registry}/${local.helm_chart_project}"
-  }
+  source            = "../../modules/kubernetes-addons/reloader"
+  harbor_oci_config = local.reloader_oci_config
 }
 
 resource "kubernetes_namespace" "harbor" {
@@ -108,6 +106,8 @@ module "harbor_core" {
     dns_sans       = local.state.metadata.global_pki_map["harbor-frontend"].dns_san
   }
 
+  helm_values_override = local.harbor_reloader_annotations
+
   ingress_config = {
     class_name      = var.harbor_helm_config.ingress_class
     tls_secret_name = var.harbor_helm_config.tls_secret_name
@@ -131,19 +131,6 @@ module "harbor_core" {
       access_key = local.minio_access_key
       secret_key = local.minio_secret_key
       endpoint   = "https://${local.minio_fqdn}" # Harbor chart uses this
-    }
-  }
-
-  helm_values_override = {
-    core = {
-      podAnnotations = {
-        "reloader.stakater.com/auto" = "true"
-      }
-    }
-    jobservice = {
-      podAnnotations = {
-        "reloader.stakater.com/auto" = "true"
-      }
     }
   }
 

--- a/terraform/layers/50-platform-harbor-frontend/outputs.tf
+++ b/terraform/layers/50-platform-harbor-frontend/outputs.tf
@@ -23,3 +23,13 @@ output "cert_manager_info" {
     issuer_name = module.platform_trust_engine.issuer_name
   }
 }
+
+output "harbor_helm_metadata" {
+  description = "Detailed metadata of the deployed Harbor Helm release"
+  value       = module.harbor_core.helm_release_metadata
+}
+
+output "reloader_helm_metadata" {
+  description = "Detailed metadata of the deployed Reloader Helm release"
+  value       = module.reloader.helm_release_metadata
+}

--- a/terraform/modules/kubernetes-addons/helm-chart-gitlab/helm-chart-official.tf
+++ b/terraform/modules/kubernetes-addons/helm-chart-gitlab/helm-chart-official.tf
@@ -289,6 +289,8 @@ resource "helm_release" "gitlab" {
           }
         }
       }
-    })
+    }),
+
+    yamlencode(var.helm_values_override)
   ]
 }

--- a/terraform/modules/kubernetes-addons/helm-chart-gitlab/outputs.tf
+++ b/terraform/modules/kubernetes-addons/helm-chart-gitlab/outputs.tf
@@ -1,0 +1,5 @@
+
+output "helm_release_metadata" {
+  description = "Status and metadata of the GitLab Helm release"
+  value       = helm_release.gitlab.metadata
+}

--- a/terraform/modules/kubernetes-addons/helm-chart-gitlab/outputs.tf
+++ b/terraform/modules/kubernetes-addons/helm-chart-gitlab/outputs.tf
@@ -1,5 +1,11 @@
 
 output "helm_release_metadata" {
-  description = "Status and metadata of the GitLab Helm release"
-  value       = helm_release.gitlab.metadata
+  description = "Basic metadata of the GitLab Helm release"
+  value = {
+    name        = helm_release.gitlab.metadata.name
+    version     = helm_release.gitlab.metadata.version
+    app_version = helm_release.gitlab.metadata.app_version
+    revision    = helm_release.gitlab.metadata.revision
+    status      = helm_release.gitlab.status
+  }
 }

--- a/terraform/modules/kubernetes-addons/helm-chart-gitlab/variables.tf
+++ b/terraform/modules/kubernetes-addons/helm-chart-gitlab/variables.tf
@@ -95,3 +95,9 @@ variable "image_registry" {
   })
   default = null
 }
+
+variable "helm_values_override" {
+  description = "Extra Helm values to override or add in HCL format"
+  type        = any
+  default     = {}
+}

--- a/terraform/modules/kubernetes-addons/helm-chart-harbor/helm-chart-official.tf
+++ b/terraform/modules/kubernetes-addons/helm-chart-harbor/helm-chart-official.tf
@@ -87,6 +87,8 @@ resource "helm_release" "harbor" {
           }
         }
       }
-    })
+    }),
+
+    yamlencode(var.helm_values_override)
   ]
 }

--- a/terraform/modules/kubernetes-addons/helm-chart-harbor/outputs.tf
+++ b/terraform/modules/kubernetes-addons/helm-chart-harbor/outputs.tf
@@ -1,0 +1,5 @@
+
+output "helm_release_metadata" {
+  description = "Status and metadata of the Harbor Helm release"
+  value       = helm_release.harbor.metadata
+}

--- a/terraform/modules/kubernetes-addons/helm-chart-harbor/outputs.tf
+++ b/terraform/modules/kubernetes-addons/helm-chart-harbor/outputs.tf
@@ -1,5 +1,11 @@
 
 output "helm_release_metadata" {
-  description = "Status and metadata of the Harbor Helm release"
-  value       = helm_release.harbor.metadata
+  description = "Basic metadata of the Harbor Helm release"
+  value = {
+    name        = helm_release.harbor.metadata.name
+    version     = helm_release.harbor.metadata.version
+    app_version = helm_release.harbor.metadata.app_version
+    revision    = helm_release.harbor.metadata.revision
+    status      = helm_release.harbor.status
+  }
 }

--- a/terraform/modules/kubernetes-addons/helm-chart-harbor/variables.tf
+++ b/terraform/modules/kubernetes-addons/helm-chart-harbor/variables.tf
@@ -69,3 +69,9 @@ variable "ca_bundle" {
     secret_name = string
   })
 }
+
+variable "helm_values_override" {
+  description = "Extra Helm values to override or add in HCL format"
+  type        = any
+  default     = {}
+}

--- a/terraform/modules/kubernetes-addons/reloader/outputs.tf
+++ b/terraform/modules/kubernetes-addons/reloader/outputs.tf
@@ -1,13 +1,13 @@
 
 output "helm_release_metadata" {
   description = "Basic metadata of the Reloader Helm release"
-  value = {
+  value = var.enabled ? {
     name        = helm_release.reloader[0].metadata.name
     version     = helm_release.reloader[0].metadata.version
     app_version = helm_release.reloader[0].metadata.app_version
     revision    = helm_release.reloader[0].metadata.revision
     status      = helm_release.reloader[0].status
-  }
+  } : null
 }
 
 output "namespace" {

--- a/terraform/modules/kubernetes-addons/reloader/outputs.tf
+++ b/terraform/modules/kubernetes-addons/reloader/outputs.tf
@@ -1,7 +1,13 @@
 
 output "helm_release_metadata" {
-  description = "Status and metadata of the Reloader Helm release"
-  value       = helm_release.reloader[0].metadata
+  description = "Basic metadata of the Reloader Helm release"
+  value = {
+    name        = helm_release.reloader[0].metadata.name
+    version     = helm_release.reloader[0].metadata.version
+    app_version = helm_release.reloader[0].metadata.app_version
+    revision    = helm_release.reloader[0].metadata.revision
+    status      = helm_release.reloader[0].status
+  }
 }
 
 output "namespace" {

--- a/terraform/modules/kubernetes-addons/reloader/outputs.tf
+++ b/terraform/modules/kubernetes-addons/reloader/outputs.tf
@@ -1,0 +1,10 @@
+
+output "helm_release_metadata" {
+  description = "Status and metadata of the Reloader Helm release"
+  value       = helm_release.reloader[0].metadata
+}
+
+output "namespace" {
+  description = "The namespace where Reloader is deployed"
+  value       = var.namespace
+}

--- a/terraform/modules/kubernetes-addons/reloader/resources.tf
+++ b/terraform/modules/kubernetes-addons/reloader/resources.tf
@@ -11,19 +11,17 @@ resource "helm_release" "reloader" {
 
   create_namespace = true
 
-  # Using attribute syntax [ { name = ..., value = ... } ] to match project standards
-  set = [
-    {
-      name  = "reloader.watchGlobally"
-      value = "true"
-    },
-    {
-      name  = "rbac.enabled"
-      value = "true"
-    }
-  ]
-
+  # Using yamlencode to ensure Booleans and structure are correctly typed
   values = [
+    yamlencode({
+      reloader = {
+        watchGlobally = true
+        logLevel      = "debug"
+        rbac = {
+          enabled = true
+        }
+      }
+    }),
     yamlencode(var.values_override)
   ]
 }

--- a/terraform/modules/kubernetes-addons/reloader/resources.tf
+++ b/terraform/modules/kubernetes-addons/reloader/resources.tf
@@ -1,0 +1,29 @@
+
+resource "helm_release" "reloader" {
+  count = var.enabled ? 1 : 0
+  name  = "reloader"
+
+  # Pointing to internal Harbor OCI synced by Ansible
+  repository = var.harbor_oci_config.repository
+  chart      = "reloader"
+  version    = var.chart_version
+  namespace  = var.namespace
+
+  create_namespace = true
+
+  # Using attribute syntax [ { name = ..., value = ... } ] to match project standards
+  set = [
+    {
+      name  = "reloader.watchGlobally"
+      value = "true"
+    },
+    {
+      name  = "rbac.enabled"
+      value = "true"
+    }
+  ]
+
+  values = [
+    yamlencode(var.values_override)
+  ]
+}

--- a/terraform/modules/kubernetes-addons/reloader/resources.tf
+++ b/terraform/modules/kubernetes-addons/reloader/resources.tf
@@ -16,7 +16,7 @@ resource "helm_release" "reloader" {
     yamlencode({
       reloader = {
         watchGlobally = true
-        logLevel      = "debug"
+        logLevel      = "info"
         rbac = {
           enabled = true
         }

--- a/terraform/modules/kubernetes-addons/reloader/variables.tf
+++ b/terraform/modules/kubernetes-addons/reloader/variables.tf
@@ -1,0 +1,31 @@
+
+variable "enabled" {
+  description = "Whether to enable Reloader"
+  type        = bool
+  default     = true
+}
+
+variable "namespace" {
+  description = "Namespace to deploy Reloader"
+  type        = string
+  default     = "reloader"
+}
+
+variable "chart_version" {
+  description = "Reloader Helm Chart version"
+  type        = string
+  default     = "2.2.11"
+}
+
+variable "values_override" {
+  description = "Custom Helm values for Reloader"
+  type        = any
+  default     = {}
+}
+
+variable "harbor_oci_config" {
+  description = "Configuration for Harbor OCI registry to pull the chart"
+  type = object({
+    repository = string
+  })
+}


### PR DESCRIPTION

## Summary

This PR primarily deploys [`stakater.github.io/stakater-charts`](https://artifacthub.io/packages/helm/stakater/reloader) to handle automated pod rollouts within the `GitLab` and `Harbor` infrastructure.

### Core Architecture

Target annotations are applied based on the specific `Helm chart` architecture of each component:

| Component      | Target Layer            | Configuration Key        |
| :------------- | :---------------------- | :----------------------- |
| `GitLab` (L50) | `Deployment Metadata`   | `deployment.annotations` |
| `Harbor` (L50) | `Pod Template Metadata` | `podAnnotations`         |

### Bug Fixes & Optimizations

- **GitLab Certificate Synchronization Mechanism**:
    - _Problem_: `GitLab` Web service failed to detect `Postgres` during the initial phase (due to reading old certificates when updates did not trigger a synchronized restart).
    - _Solution_: Introduced `Reloader` mechanism to monitor `gitlab-postgres-tls`, ensuring automatic Pod rolling updates after certificate rotation.

### Operational Workflow

To verify whether `Reloader` correctly monitors `Secret` changes across clusters, the following operations can be performed:

1. Execute a simulated trigger on the `GitLab` node and observe changes in its `Deployment Generation`:

    ```bash
    kubectl get secret -n gitlab gitlab-ca-bundle -o json | jq ".data[\"reloader-manual-trigger\"] = (\"$(date +%s)\" | @base64)" | kubectl apply -f -
    ```

    The same logic can be executed on the `Harbor` node:

    ```bash
    kubectl get secret -n harbor harbor-ca-bundle -o json | jq ".data[\"reloader-final-validation\"] = (\"$(date +%s)\" | @base64)" | kubectl apply -f -
    ```

2. During this period, confirm that changes are detected and patches are triggered by monitoring the `Reloader` controller logs:

    ```bash
    kubectl logs -n reloader -l app.kubernetes.io/name=reloader --tail=20
    ```

3. After confirming the trigger, the contents of step 1 can be re-executed. Once complete, clean up the commands to remove test fields and restore the `Secret` to a clean state:

    ```bash
    kubectl get secret -n harbor harbor-ca-bundle -o json | jq 'del(.data["reloader-final-validation"])' | kubectl apply -f -
    kubectl get secret -n gitlab gitlab-ca-bundle -o json | jq 'del(.data["reloader-manual-trigger"])' | kubectl apply -f -
    ```

### Verification

- [x] **GitLab Verification**: After manually updating `gitlab-ca-bundle`, successfully triggered automatic rolling updates for `webservice` and `sidekiq`, resetting `AGE`.
- [x] **Harbor Verification**: Performed manual trigger tests on `harbor-ca-bundle`, confirming all `core`, `jobservice`, and `registry` components restarted (`Generation 15` → `16`).
- [x] **Log Audit**: Confirmed cross-namespace monitoring is functioning correctly via `Reloader` debug logs, and patch actions after detecting `Secret` changes are accurate.
