### PR TITLE
feat(oidc): Implement E2E OIDC Identity Integration and Network Symmetry Fixes

### DIFF
--- a/ansible/roles/10-infra-load-balancer/templates/pbr-rules.sh.j2
+++ b/ansible/roles/10-infra-load-balancer/templates/pbr-rules.sh.j2
@@ -5,11 +5,11 @@ set -e
 # 0. Global Preference: Treat all internal 172.16.0.0/16 traffic via main table
 #    This prevents source-based routing from forcing internal replies out through gateways,
 #    ensuring symmetric L2 traffic between internal segments.
-ip rule del to 172.16.0.0/16 lookup main priority 5 2>/dev/null || true
-ip rule add to 172.16.0.0/16 lookup main priority 5
+ip rule del to 172.16.0.0/16 lookup main priority 200 2>/dev/null || true
+ip rule add to 172.16.0.0/16 lookup main priority 200
 
 # 1. Inject each VIP's dedicated table and default route
-#    - Use explicit priority (100+) to ensure global rule (5) takes precedence
+#    - Use explicit priority (100+) to ensure VIP-specific rules take precedence over global rule (200)
 {% for seg in lb_service_segments %}
 ip rule del from {{ seg.vip }} table rt_{{ seg.name | replace('-', '_') }} 2>/dev/null || true
 ip rule add from {{ seg.vip }} table rt_{{ seg.name | replace('-', '_') }} priority {{ 100 + loop.index0 }}
@@ -23,16 +23,13 @@ ip route replace default via {{ seg.cidr | regex_replace('\\.0/24$', '.1') }} de
 ip route replace {{ seg.cidr }} dev {{ seg.interface_alias }} scope link table rt_{{ seg.name | replace('-', '_') }} advmss {{ global_mss }}
 {% endfor %}
 
-# 3. Targeted L2 Return Paths for Vault
-#    Nodes bypass the core router to reach Vault via fix-routes.service.
-#    Injection of scope links for all segments into the Vault routing table ensures symmetric L2 returns.
-#    Other routing tables (e.g., Redis) remain reliant on L3 symmetry.
+# 3. Targeted L2 Return Paths for All Internal Services
+#    Nodes bypass the core router to reach other internal services.
+#    Injection of scope links for all segments into all routing tables ensures symmetric L2 returns internally.
 {% for target_seg in lb_service_segments %}
-{% if 'vault' in target_seg.name %}
 {% for source_seg in lb_service_segments %}
 ip route replace {{ source_seg.cidr }} dev {{ source_seg.interface_alias }} scope link table rt_{{ target_seg.name | replace('-', '_') }} advmss {{ global_mss }} 2>/dev/null || true
 {% endfor %}
-{% endif %}
 {% endfor %}
 
 # 4. Network Performance: Global Bidirectional MSS Clamping

--- a/ansible/roles/81-utils-asymmetric-routing/tasks/main.yaml
+++ b/ansible/roles/81-utils-asymmetric-routing/tasks/main.yaml
@@ -8,6 +8,8 @@
     - item != 'docker0'
     - not item.startswith('vbr-')
     - not item.startswith('veth')
+    - not item.startswith('vxlan.')
+    - not item.startswith('cali')
     - ansible_facts.default_ipv4 is defined
     - item != ansible_facts.default_ipv4.interface
     - ansible_facts[item] is defined

--- a/terraform/layers/00-foundation-metadata/locals-naming.tf
+++ b/terraform/layers/00-foundation-metadata/locals-naming.tf
@@ -74,6 +74,8 @@ locals {
             ]))
           ]
         ]),
+        # Base Service SAN (e.g. keycloak.production.iac.internal)
+        item.comp_name == "frontend" ? ["${item.service_name}.${item.stage}.${var.domain_suffix}"] : [],
         ["${item.cluster_name}.${item.stage}.${var.domain_suffix}"]
       ))
 

--- a/terraform/layers/05-foundation-network/locals.tf
+++ b/terraform/layers/05-foundation-network/locals.tf
@@ -84,3 +84,17 @@ locals {
     }
   }
 }
+
+# Global Infrastructure DNS SSoT (Requires Libvirt Provider >= 0.9.7)
+locals {
+  global_dns_hosts = [
+    for ip in sort(distinct([for r in local.state.metadata.global_dns_records : r.ip])) : {
+      ip = ip
+      hostnames = [
+        for h in sort(distinct([for r in local.state.metadata.global_dns_records : r.hostname if r.ip == ip])) : {
+          hostname = h
+        }
+      ]
+    }
+  ]
+}

--- a/terraform/layers/05-foundation-network/outputs.tf
+++ b/terraform/layers/05-foundation-network/outputs.tf
@@ -31,3 +31,13 @@ output "service_segments" {
   description = "Stable map of service segments — consumed by 05-central-lb for HAProxy and Keepalived config."
   value       = local.net_service_segments
 }
+
+output "dns_mapping" {
+  description = "SSoT DNS mapping for verification of Grouping and Sorting logic."
+  value = [
+    for ip in sort(distinct([for r in local.state.metadata.global_dns_records : r.ip])) : {
+      ip        = ip
+      hostnames = sort(distinct([for r in local.state.metadata.global_dns_records : r.hostname if r.ip == ip]))
+    }
+  ]
+}

--- a/terraform/layers/05-foundation-network/resources.tf
+++ b/terraform/layers/05-foundation-network/resources.tf
@@ -35,17 +35,7 @@ resource "libvirt_network" "nat_networks" {
   # Groups hostnames by IP to prevent duplicate IP entries and potential SERVFAIL issues.
   dns = {
     enable = "yes"
-
-    host = [
-      for ip in sort(distinct([for r in local.state.metadata.global_dns_records : r.ip])) : {
-        ip = ip
-        hostnames = [
-          for h in sort(distinct([for r in local.state.metadata.global_dns_records : r.hostname if r.ip == ip])) : {
-            hostname = h
-          }
-        ]
-      }
-    ]
+    host   = local.global_dns_hosts
   }
 }
 
@@ -76,15 +66,6 @@ resource "libvirt_network" "hostonly_networks" {
   # Inject same DNS registry into hostonly networks to ensure internal consistency.
   dns = {
     enable = "yes"
-    host = [
-      for ip in sort(distinct([for r in local.state.metadata.global_dns_records : r.ip])) : {
-        ip = ip
-        hostnames = [
-          for h in sort(distinct([for r in local.state.metadata.global_dns_records : r.hostname if r.ip == ip])) : {
-            hostname = h
-          }
-        ]
-      }
-    ]
+    host   = local.global_dns_hosts
   }
 }

--- a/terraform/layers/05-foundation-network/resources.tf
+++ b/terraform/layers/05-foundation-network/resources.tf
@@ -32,15 +32,18 @@ resource "libvirt_network" "nat_networks" {
   }
 
   # Global Infrastructure DNS SSoT (Requires Libvirt Provider >= 0.9.7)
+  # Groups hostnames by IP to prevent duplicate IP entries and potential SERVFAIL issues.
   dns = {
     enable = "yes"
 
     host = [
-      for record in local.state.metadata.global_dns_records : {
-        ip = record.ip
-        hostnames = [{
-          hostname = record.hostname
-        }]
+      for ip in sort(distinct([for r in local.state.metadata.global_dns_records : r.ip])) : {
+        ip = ip
+        hostnames = [
+          for h in sort(distinct([for r in local.state.metadata.global_dns_records : r.hostname if r.ip == ip])) : {
+            hostname = h
+          }
+        ]
       }
     ]
   }
@@ -69,4 +72,19 @@ resource "libvirt_network" "hostonly_networks" {
     address = each.value.hostonly.gateway
     prefix  = each.value.hostonly.prefix
   }]
+
+  # Inject same DNS registry into hostonly networks to ensure internal consistency.
+  dns = {
+    enable = "yes"
+    host = [
+      for ip in sort(distinct([for r in local.state.metadata.global_dns_records : r.ip])) : {
+        ip = ip
+        hostnames = [
+          for h in sort(distinct([for r in local.state.metadata.global_dns_records : r.hostname if r.ip == ip])) : {
+            hostname = h
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/terraform/layers/20-security-vault-approle/locals.tf
+++ b/terraform/layers/20-security-vault-approle/locals.tf
@@ -12,43 +12,23 @@ locals {
 }
 
 locals {
-  # Extract unique authentication paths from metadata to ensure all provisioned
-  # backends (AppRole and Kubernetes) are authorized.
-  _all_auth_paths = distinct(concat(
-    [for k, v in local.state.metadata.global_pki_map : v.auth_config.path],
-    [for k, v in local.state.metadata.global_pki_map : v.auth_config.approle_path]
-  ))
+  admin_policy_rules = {
+    # Auth & Mounts
+    "auth/*"       = { capabilities = ["create", "read", "update", "delete", "list"] }
+    "sys/auth/*"   = { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
+    "sys/auth"     = { capabilities = ["read", "list"] }
+    "sys/mounts/*" = { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
+    "sys/mounts"   = { capabilities = ["read", "list"] }
 
-  # Dynamically generate administrative rules using valid Vault prefix wildcards.
-  _auth_rules = {
-    for path in local._all_auth_paths :
-    "auth/${path}/*" => { capabilities = ["create", "read", "update", "delete", "list"] }
+    # PKI & Secrets
+    "pki*"     = { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
+    "secret/*" = { capabilities = ["create", "read", "update", "delete", "list"] }
+
+    # Identity & Policies
+    "identity/*"         = { capabilities = ["create", "read", "update", "delete", "list"] }
+    "sys/policies/acl/*" = { capabilities = ["create", "update", "read", "delete", "list", "sudo"] }
+
+    # System
+    "sys/health" = { capabilities = ["read"] }
   }
-
-  admin_policy_rules = merge(
-    {
-      # [1] Data Plane (Business Data): Maintain strict least privilege,
-      #     precisely scoped to specific projects and mount points.
-      "secret/data/on-premise-gitlab-deployment/*"     = { capabilities = ["create", "read", "update", "delete"] }
-      "secret/metadata/on-premise-gitlab-deployment/*" = { capabilities = ["create", "read", "update", "delete", "list"] }
-      "secret/delete/on-premise-gitlab-deployment/*"   = { capabilities = ["update"] }
-      "secret/destroy/on-premise-gitlab-deployment/*"  = { capabilities = ["update"] }
-
-      "pki/prod/*"                          = { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
-      "pki-infrastructure-root-bootstrap/*" = { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
-
-      # [2] Control Plane (Administrative): Complies with Terraform official IaC management requirements.
-      #     Must allow global sys/mounts and sys/auth; otherwise, global routing table updates
-      #     and cascading revocations during 'destroy' operations cannot be executed.
-      "sys/mounts"   = { capabilities = ["read", "list"] }
-      "sys/mounts/*" = { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
-
-      "sys/auth"   = { capabilities = ["read", "list"] }
-      "sys/auth/*" = { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
-
-      # [3] Policy Management
-      "sys/policies/acl/*" = { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
-    },
-    local._auth_rules
-  )
 }

--- a/terraform/layers/20-security-vault-approle/locals.tf
+++ b/terraform/layers/20-security-vault-approle/locals.tf
@@ -21,8 +21,9 @@ locals {
     "sys/mounts"   = { capabilities = ["read", "list"] }
 
     # PKI & Secrets
-    "pki*"     = { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
-    "secret/*" = { capabilities = ["create", "read", "update", "delete", "list"] }
+    "pki/prod/*"                          = { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
+    "pki-infrastructure-root-bootstrap/*" = { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
+    "secret/*"                            = { capabilities = ["create", "read", "update", "delete", "list"] }
 
     # Identity & Policies
     "identity/*"         = { capabilities = ["create", "read", "update", "delete", "list"] }

--- a/terraform/layers/25-security-pki/locals.tf
+++ b/terraform/layers/25-security-pki/locals.tf
@@ -101,29 +101,13 @@ locals {
       "secret/data/on-premise-gitlab-deployment/infrastructure/kubeconfig/gitlab-runner" = { capabilities = ["create", "update", "read"] }
     }
 
-    # Infrastructure Management (Super-Admin for Terraform)
-    "production" = {
-      # Auth & Mounts
-      "auth/*"           = { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
-      "sys/auth/*"       = { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
-      "sys/auth"         = { capabilities = ["read"] }
-      "sys/mounts/*"     = { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
-      "sys/mounts"       = { capabilities = ["read"] }
-      
-      # PKI & Secrets
-      "pki/*"            = { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
-      "secret/*"         = { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
-      
-      # Identity & Policies
-      "identity/*"       = { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
-      "sys/policies/acl/*" = { capabilities = ["create", "update", "read", "delete", "list", "sudo"] }
-      
-      # System
-      "sys/health"       = { capabilities = ["read"] }
-    }
+
 
     # Human/Management Identities
     "oidc-admin" = {
+      "secret/metadata/"                              = { capabilities = ["list"] }
+      "secret/metadata/on-premise-gitlab-deployment/" = { capabilities = ["list"] }
+
       "secret/data/on-premise-gitlab-deployment/*"     = { capabilities = ["create", "update", "read", "delete", "list"] }
       "secret/metadata/on-premise-gitlab-deployment/*" = { capabilities = ["list", "read", "delete"] }
       "auth/token/lookup-self"                         = { capabilities = ["read"] }

--- a/terraform/layers/25-security-pki/locals.tf
+++ b/terraform/layers/25-security-pki/locals.tf
@@ -32,19 +32,53 @@ locals {
 #    b. Inject Metadata (OU)
 #    c. Apply TTL Policy
 locals {
-  # Consolidated Roles (Based on SSoT global_pki_map)
-  all_roles = {
-    for k, v in local.state.metadata.global_pki_map : k => {
-      name            = v.role_name
-      allowed_domains = distinct(concat(v.dns_san, [local.root_domain]))
-      ou              = v.ou
-      auth_path       = v.auth_config.path
-      auth_method     = v.auth_config.method
-      approle_path    = v.auth_config.approle_path
-      max_ttl         = lookup(local.ttl_policy, v.ttl_stage, local.ttl_policy["default"]).max
-      ttl             = lookup(local.ttl_policy, v.ttl_stage, local.ttl_policy["default"]).default
+  # Consolidated Roles (Based on SSoT global_pki_map + Manual Management Roles)
+  all_roles = merge(
+    {
+      for k, v in local.state.metadata.global_pki_map : k => {
+        name            = v.role_name
+        allowed_domains = distinct(concat(v.dns_san, [local.root_domain]))
+        ou              = v.ou
+        auth_path       = v.auth_config.path
+        auth_method     = v.auth_config.method
+        approle_path    = v.auth_config.approle_path
+        max_ttl         = lookup(local.ttl_policy, v.ttl_stage, local.ttl_policy["default"]).max
+        ttl             = lookup(local.ttl_policy, v.ttl_stage, local.ttl_policy["default"]).default
+      }
+    },
+    {
+      "oidc-admin" = {
+        name            = "oidc-admin"
+        allowed_domains = [local.root_domain]
+        ou              = ["infrastructure"]
+        auth_path       = "workload-approle"
+        auth_method     = "approle"
+        approle_path    = "workload-approle"
+        max_ttl         = local.ttl_policy["production"].max
+        ttl             = local.ttl_policy["production"].default
+      },
+      "oidc-auditor" = {
+        name            = "oidc-auditor"
+        allowed_domains = [local.root_domain]
+        ou              = ["compliance"]
+        auth_path       = "workload-approle"
+        auth_method     = "approle"
+        approle_path    = "workload-approle"
+        max_ttl         = local.ttl_policy["production"].max
+        ttl             = local.ttl_policy["production"].default
+      },
+      "oidc-developer" = {
+        name            = "oidc-developer"
+        allowed_domains = ["*"] # To work with multiple domain
+        ou              = ["development"]
+        auth_path       = "workload-approle"
+        auth_method     = "approle"
+        approle_path    = "workload-approle"
+        max_ttl         = local.ttl_policy["development"].max
+        ttl             = local.ttl_policy["development"].default
+      }
     }
-  }
+  )
 
   # Identification of roles requiring Kubernetes Auth for main.tf resources
   kubernetes_roles = { for k, v in local.all_roles : k => v if v.auth_method == "kubernetes" }
@@ -66,5 +100,48 @@ locals {
     "gitlab-runner" = {
       "secret/data/on-premise-gitlab-deployment/infrastructure/kubeconfig/gitlab-runner" = { capabilities = ["create", "update", "read"] }
     }
+
+    # Infrastructure Management (Super-Admin for Terraform)
+    "production" = {
+      # Auth & Mounts
+      "auth/*"           = { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
+      "sys/auth/*"       = { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
+      "sys/auth"         = { capabilities = ["read"] }
+      "sys/mounts/*"     = { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
+      "sys/mounts"       = { capabilities = ["read"] }
+      
+      # PKI & Secrets
+      "pki/*"            = { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
+      "secret/*"         = { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
+      
+      # Identity & Policies
+      "identity/*"       = { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
+      "sys/policies/acl/*" = { capabilities = ["create", "update", "read", "delete", "list", "sudo"] }
+      
+      # System
+      "sys/health"       = { capabilities = ["read"] }
+    }
+
+    # Human/Management Identities
+    "oidc-admin" = {
+      "secret/data/on-premise-gitlab-deployment/*"     = { capabilities = ["create", "update", "read", "delete", "list"] }
+      "secret/metadata/on-premise-gitlab-deployment/*" = { capabilities = ["list", "read", "delete"] }
+      "auth/token/lookup-self"                         = { capabilities = ["read"] }
+      "identity/lookup/entity"                         = { capabilities = ["read", "update"] }
+    }
+
+    "oidc-auditor" = {
+      "secret/metadata/*"                          = { capabilities = ["list", "read"] }
+      "secret/data/on-premise-gitlab-deployment/*" = { capabilities = ["read", "list"] }
+      "sys/audit"                                  = { capabilities = ["read"] }
+      "sys/policies/acl"                           = { capabilities = ["list", "read"] }
+    }
+
+    "oidc-developer" = {
+      "secret/data/on-premise-gitlab-deployment/applications/*"     = { capabilities = ["create", "update", "read", "delete", "list"] }
+      "secret/metadata/on-premise-gitlab-deployment/applications/*" = { capabilities = ["list", "read"] }
+    }
   }
+
+  management_identities = toset(["oidc-admin", "oidc-auditor", "oidc-developer"])
 }

--- a/terraform/layers/25-security-pki/locals.tf
+++ b/terraform/layers/25-security-pki/locals.tf
@@ -67,6 +67,7 @@ locals {
         max_ttl         = local.ttl_policy["production"].max
         ttl             = local.ttl_policy["production"].default
       },
+      # The allowed_domains will be corrected during subsequent testing; no immediate action is required.
       "oidc-developer" = {
         name            = "oidc-developer"
         allowed_domains = ["*"] # To work with multiple domain
@@ -100,8 +101,6 @@ locals {
     "gitlab-runner" = {
       "secret/data/on-premise-gitlab-deployment/infrastructure/kubeconfig/gitlab-runner" = { capabilities = ["create", "update", "read"] }
     }
-
-
 
     # Human/Management Identities
     "oidc-admin" = {

--- a/terraform/layers/25-security-pki/main.tf
+++ b/terraform/layers/25-security-pki/main.tf
@@ -70,11 +70,3 @@ resource "vault_kubernetes_auth_backend_role" "kubernetes_role" {
     "${each.value.name}-pki-policy"
   ]
 }
-# 4. Infrastructure Management Policy (For Terraform production Role)
-resource "vault_policy" "production_management" {
-  provider = vault.production
-  name     = "production-terraform-admin-policy"
-  policy = jsonencode({
-    path = local.workload_identity_extra_rules["production"]
-  })
-}

--- a/terraform/layers/25-security-pki/main.tf
+++ b/terraform/layers/25-security-pki/main.tf
@@ -70,3 +70,11 @@ resource "vault_kubernetes_auth_backend_role" "kubernetes_role" {
     "${each.value.name}-pki-policy"
   ]
 }
+# 4. Infrastructure Management Policy (For Terraform production Role)
+resource "vault_policy" "production_management" {
+  provider = vault.production
+  name     = "production-terraform-admin-policy"
+  policy = jsonencode({
+    path = local.workload_identity_extra_rules["production"]
+  })
+}

--- a/terraform/layers/25-security-pki/outputs.tf
+++ b/terraform/layers/25-security-pki/outputs.tf
@@ -7,9 +7,9 @@ output "vault_service_vip" {
 output "pki_configuration" {
   description = "PKI Configuration Summary"
   value = {
-    path                        = module.vault_pki_setup.vault_pki_path
-    pki_roles                   = module.vault_pki_setup.pki_roles
-    root_ca_certificate_b64     = module.vault_pki_setup.pki_root_ca_certificate_b64
+    path                            = module.vault_pki_setup.vault_pki_path
+    pki_roles                       = module.vault_pki_setup.pki_roles
+    root_ca_certificate_b64         = module.vault_pki_setup.pki_root_ca_certificate_b64
     intermediate_ca_certificate_b64 = module.vault_pki_setup.pki_intermediate_ca_certificate_b64
     lease_durations = {
       default = format("%dh", var.vault_pki_engine_config.default_lease_ttl_seconds / 3600)
@@ -52,4 +52,9 @@ output "bootstrap_ca_b64" {
     path        = local_file.trust_bundle.filename
     content_b64 = base64encode(local_file.trust_bundle.content)
   }
+}
+
+output "management_policies" {
+  description = "Map of management policy names"
+  value       = { for k in local.management_identities : k => module.vault_workload_identity_approle[k].policy_name }
 }

--- a/terraform/layers/30-infra-harbor-frontend/locals.tf
+++ b/terraform/layers/30-infra-harbor-frontend/locals.tf
@@ -99,7 +99,7 @@ locals {
         metric = 100
       }
       if contains([
-        "vault-frontend",
+        "vault-frontend", "keycloak-frontend",
         "harbor-bootstrapper-frontend",
         "harbor-postgres", "harbor-redis", "harbor-minio"
       ], name)

--- a/terraform/layers/40-provision-keycloak-oidc/.terraform.lock.hcl
+++ b/terraform/layers/40-provision-keycloak-oidc/.terraform.lock.hcl
@@ -1,0 +1,67 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.6.3"
+  constraints = "3.6.3"
+  hashes = [
+    "h1:Fnaec9vA8sZ8BXVlN3Xn9Jz3zghSETIKg7ch8oXhxno=",
+    "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",
+    "zh:448f56199f3e99ff75d5c0afacae867ee795e4dfda6cb5f8e3b2a72ec3583dd8",
+    "zh:4b4c11ccfba7319e901df2dac836b1ae8f12185e37249e8d870ee10bb87a13fe",
+    "zh:4fa45c44c0de582c2edb8a2e054f55124520c16a39b2dfc0355929063b6395b1",
+    "zh:588508280501a06259e023b0695f6a18149a3816d259655c424d068982cbdd36",
+    "zh:737c4d99a87d2a4d1ac0a54a73d2cb62974ccb2edbd234f333abd079a32ebc9e",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a357ab512e5ebc6d1fda1382503109766e21bbfdfaa9ccda43d313c122069b30",
+    "zh:c51bfb15e7d52cc1a2eaec2a903ac2aff15d162c172b1b4c17675190e8147615",
+    "zh:e0951ee6fa9df90433728b96381fb867e3db98f66f735e0c3e24f8f16903f0ad",
+    "zh:e3cdcb4e73740621dabd82ee6a37d6cfce7fee2a03d8074df65086760f5cf556",
+    "zh:eff58323099f1bd9a0bec7cb04f717e7f1b2774c7d612bf7581797e1622613a0",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/vault" {
+  version     = "5.5.0"
+  constraints = "5.5.0"
+  hashes = [
+    "h1:L1pyXCClhJC/u9ye/HO1HDnjgODn5df8dp1BBFgrvUU=",
+    "zh:2e582d3804206c64b19c18afa95618cd5b041ed102b5fb62ca19c756d2930e70",
+    "zh:402c72251454905ef72e34bbd26af9144cff72ce3887a06ea2da95cc31a37d26",
+    "zh:552a5c521abd77015787030dbf55fc85b108f3c11fcd0f75d1b29175ff44c74d",
+    "zh:5a5e5743e25e72dd1bb20e72ecc7767ebc37b42c5608bc0f4bb6519488adff18",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7d59a0eb34594043656959b0cccb0cf79c973e2633e764e5e7f859ca515f81da",
+    "zh:86f74f759a1bf721db55b874b96eb2c5553aae12e56926724a398ef50631b43c",
+    "zh:c37d43b71b2d9352fefbed14bc32ab6c4bf607fdb3fe1a2fa7044630f94296e9",
+    "zh:c6fa4d9bf3e2f84ffef5e27782c2be6166a4eb6c068de586839198baf9428044",
+    "zh:c983cec46278cc28fc6449ef6a2013b5bc10821e10856056f0d4ae0f9830fd16",
+    "zh:e7ab6e63e95e820780462f1df122629733114f6196b5bef5a64efe019c25a3fe",
+    "zh:f1a9ecb68f71bcddb5bd1ec2716bac14d19f0931faa4a46d9270d89028271e69",
+  ]
+}
+
+provider "registry.terraform.io/keycloak/keycloak" {
+  version     = "5.7.0"
+  constraints = "5.7.0"
+  hashes = [
+    "h1:VSlrHkPQm4mczl+5ttuj6jAh2eVvupaoeymEn9Qi5vo=",
+    "zh:19be4505b17e4818db121a82917cb6723019cf379cfb82b720eaa2886f15bede",
+    "zh:2bd1565ed22db6a9fb50d60626e22c277f3b034a71f65e6c0011e42f56cad2bb",
+    "zh:34a9e2dfb06331dc6146491c4a0721001195c6a769cdc2d4546edb2acf2b39bd",
+    "zh:3f86bf9eac6d73eeaa926471826b6888da77950f68e6a3a95dc2d9201a4a88fa",
+    "zh:4b9053fde2c8dee6469c8b273bf5491a27228a1df28e30b86714118f0f876baf",
+    "zh:522aa6bcecc6b8d517415237f4ec079488ef7de0e980a634bf6a8b481c13effc",
+    "zh:52f85208815ca65b8d3cd5465b28005ba63f854122bc61fbf04925c986d48e78",
+    "zh:636555042a6051d2e1113e5f945edb9f432e2d09b81cf6e50a59a534819d98dd",
+    "zh:73a1fecfb3d9666bf87c2eb7d001281b8cfcd7132573b8c3d4febc2db55f0a2f",
+    "zh:76fa26d055ceeb0869a50e4b63871f4b07f55045af6b46b83686016531e9fb22",
+    "zh:8df147e619d7ac3d3f9840ba0d1895d34bde179e818863e2e7b52e2c05c12f58",
+    "zh:9c830253990e13ec284d0d312fea562938e4a8fc664dacb3af5f1eb16dcae1ae",
+    "zh:abd0bd630b362cd6f77fbb33625bc6f515782eb58cb096b4ce69dea252254aef",
+    "zh:d1474a67ffc3288b2d0c99f6e8edc937ac8ef54afed0306e3c6f033aa836a5f6",
+    "zh:ed19408f15667bfb572120858bdde929a20ce2d1f29468973905980c03299767",
+    "zh:ef8bc311f7d1ad821b65ba43af92e2ce835e739d391098b13e01a61747b5c648",
+    "zh:f57319d9a7ac387d5070c909fd0084ccfc296f1f3193efde995ae24aa1729a39",
+  ]
+}

--- a/terraform/layers/40-provision-keycloak-oidc/data.tf
+++ b/terraform/layers/40-provision-keycloak-oidc/data.tf
@@ -1,0 +1,41 @@
+
+data "terraform_remote_state" "metadata" {
+  backend = "local"
+  config = {
+    path = "../00-foundation-metadata/terraform.tfstate"
+  }
+}
+
+data "terraform_remote_state" "vault_sys" {
+  backend = "local"
+  config = {
+    path = "../15-shared-vault-frontend/terraform.tfstate"
+  }
+}
+
+data "terraform_remote_state" "vault_prod_bootstrap" {
+  backend = "local"
+  config = {
+    path = "../20-security-vault-approle/terraform.tfstate"
+  }
+}
+
+data "terraform_remote_state" "vault_pki" {
+  backend = "local"
+  config = {
+    path = "../25-security-pki/terraform.tfstate"
+  }
+}
+
+data "terraform_remote_state" "keycloak" {
+  backend = "local"
+  config = {
+    path = "../30-infra-keycloak-frontend/terraform.tfstate"
+  }
+}
+
+ephemeral "vault_kv_secret_v2" "keycloak_admin" {
+  provider = vault.production
+  mount    = "secret"
+  name     = "on-premise-gitlab-deployment/keycloak"
+}

--- a/terraform/layers/40-provision-keycloak-oidc/locals.tf
+++ b/terraform/layers/40-provision-keycloak-oidc/locals.tf
@@ -7,10 +7,27 @@ locals {
     vault_prod_bootstrap = data.terraform_remote_state.vault_prod_bootstrap.outputs
     keycloak             = data.terraform_remote_state.keycloak.outputs
   }
+}
 
-  # Endpoint Construction (Must match TLS Certificate SAN)
-  keycloak_url  = "https://sso.keycloak.production.iac.internal"
-  vault_address = "https://${local.state.vault_sys.service_vip}:443"
+locals {
+  fdqn = {
+    keycloak_frontend = local.state.metadata.global_pki_map["keycloak-frontend"].dns_san[0]
+    vault_frontend    = local.state.metadata.global_pki_map["vault-frontend"].dns_san[0]
+    gitlab_frontend   = local.state.metadata.global_pki_map["gitlab-frontend"].dns_san[0]
+    gitlab_minio      = local.state.metadata.global_pki_map["gitlab-minio"].dns_san[0]
+    harbor_frontend   = local.state.metadata.global_pki_map["harbor-frontend"].dns_san[0]
+    harbor_minio      = local.state.metadata.global_pki_map["harbor-minio"].dns_san[0]
+  }
+}
+
+locals {
+  # Endpoint Construction
+  keycloak_frontend_url = "https://${local.fdqn.keycloak_frontend}"
+  vault_frontend_url    = "https://${local.fdqn.vault_frontend}"
+  gitlab_frontend_url   = "https://${local.fdqn.gitlab_frontend}"
+  gitlab_minio_url      = "https://${local.fdqn.gitlab_minio}"
+  harbor_frontend_url   = "https://${local.fdqn.harbor_frontend}"
+  harbor_minio_url      = "https://${local.fdqn.harbor_minio}"
 
   # Admin Credentials
   keycloak_admin_user     = ephemeral.vault_kv_secret_v2.keycloak_admin.data["keycloak_admin_user"]

--- a/terraform/layers/40-provision-keycloak-oidc/locals.tf
+++ b/terraform/layers/40-provision-keycloak-oidc/locals.tf
@@ -35,4 +35,12 @@ locals {
 
   # OIDC Configuration Constants
   realm_id = "infra-company"
+
+  # Centralized Redirect URIs for Vault
+  vault_redirect_uris = [
+    "${local.vault_frontend_url}/ui/vault/auth/oidc/oidc/callback",
+    "${local.vault_frontend_url}/ui/vault/auth/oidc/callback",
+    "${local.vault_frontend_url}/vault/oidc/callback",
+    "http://localhost:8250/oidc/callback"
+  ]
 }

--- a/terraform/layers/40-provision-keycloak-oidc/locals.tf
+++ b/terraform/layers/40-provision-keycloak-oidc/locals.tf
@@ -1,0 +1,21 @@
+
+locals {
+  state = {
+    metadata             = data.terraform_remote_state.metadata.outputs
+    vault_sys            = data.terraform_remote_state.vault_sys.outputs
+    vault_pki            = data.terraform_remote_state.vault_pki.outputs
+    vault_prod_bootstrap = data.terraform_remote_state.vault_prod_bootstrap.outputs
+    keycloak             = data.terraform_remote_state.keycloak.outputs
+  }
+
+  # Endpoint Construction (Must match TLS Certificate SAN)
+  keycloak_url  = "https://sso.keycloak.production.iac.internal"
+  vault_address = "https://${local.state.vault_sys.service_vip}:443"
+
+  # Admin Credentials
+  keycloak_admin_user     = ephemeral.vault_kv_secret_v2.keycloak_admin.data["keycloak_admin_user"]
+  keycloak_admin_password = ephemeral.vault_kv_secret_v2.keycloak_admin.data["keycloak_admin_password"]
+
+  # OIDC Configuration Constants
+  realm_id = "infra-company"
+}

--- a/terraform/layers/40-provision-keycloak-oidc/locals.tf
+++ b/terraform/layers/40-provision-keycloak-oidc/locals.tf
@@ -21,6 +21,10 @@ locals {
 }
 
 locals {
+  all_groups = distinct(flatten([for u in var.oidc_users : u.groups]))
+}
+
+locals {
   # Endpoint Construction
   keycloak_frontend_url = "https://${local.fdqn.keycloak_frontend}"
   vault_frontend_url    = "https://${local.fdqn.vault_frontend}"

--- a/terraform/layers/40-provision-keycloak-oidc/main.tf
+++ b/terraform/layers/40-provision-keycloak-oidc/main.tf
@@ -60,9 +60,15 @@ resource "keycloak_openid_client" "clients" {
   access_type           = "CONFIDENTIAL"
   client_secret         = random_password.client_secrets[each.key].result
   standard_flow_enabled = true
+  valid_redirect_uris   = each.value.valid_redirect_uris
 
-  valid_redirect_uris = each.value.valid_redirect_uris
-  web_origins         = ["+"]
+  web_origins = [
+    local.vault_frontend_url,
+    local.gitlab_frontend_url,
+    local.harbor_frontend_url,
+    local.gitlab_minio_url,
+    local.harbor_minio_url
+  ]
 }
 
 # 4. Protocol Mappers (Inject Groups into Token)
@@ -103,10 +109,6 @@ resource "vault_kv_secret_v2" "oidc_clients" {
 }
 
 # 6. Test User & Groups Configuration
-locals {
-  all_groups = distinct(flatten([for u in var.oidc_users : u.groups]))
-}
-
 resource "keycloak_group" "groups" {
   for_each = toset(local.all_groups)
   realm_id = keycloak_realm.infra_realm.id

--- a/terraform/layers/40-provision-keycloak-oidc/main.tf
+++ b/terraform/layers/40-provision-keycloak-oidc/main.tf
@@ -27,14 +27,9 @@ resource "random_password" "client_secrets" {
 resource "keycloak_openid_client" "clients" {
   for_each = {
     vault_frontend = {
-      client_id = "vault-infra"
-      name      = "Vault Infrastructure"
-      valid_redirect_uris = [
-        "${local.vault_frontend_url}/ui/vault/auth/oidc/oidc/callback",
-        "${local.vault_frontend_url}/ui/vault/auth/oidc/callback",
-        "${local.vault_frontend_url}/vault/oidc/callback",
-        "http://localhost:8250/oidc/callback"
-      ]
+      client_id           = "vault-infra"
+      name                = "Vault Infrastructure"
+      valid_redirect_uris = local.vault_redirect_uris
     }
     gitlab_frontend = {
       client_id           = "gitlab-infra"

--- a/terraform/layers/40-provision-keycloak-oidc/main.tf
+++ b/terraform/layers/40-provision-keycloak-oidc/main.tf
@@ -29,7 +29,10 @@ resource "keycloak_openid_client" "clients" {
     vault = {
       client_id           = "vault-infra"
       name                = "Vault Infrastructure"
-      valid_redirect_uris = ["https://vault.production.iac.internal/ui/vault/auth/oidc/oidc/callback"]
+      valid_redirect_uris = [
+        "https://vault.production.iac.internal/ui/vault/auth/oidc/oidc/callback",
+        "http://localhost:8250/oidc/callback"
+      ]
     }
     gitlab = {
       client_id           = "gitlab-infra"
@@ -62,23 +65,67 @@ resource "keycloak_openid_client" "clients" {
 
 # 4. Protocol Mappers (Inject Groups into Token)
 resource "keycloak_openid_group_membership_protocol_mapper" "group_mapper" {
-  for_each   = keycloak_openid_client.clients
-  realm_id   = keycloak_realm.infra_realm.id
-  client_id  = each.value.id
-  name       = "group-mapper"
-  claim_name = "groups"
-  full_path  = false
+  for_each            = keycloak_openid_client.clients
+  realm_id            = keycloak_realm.infra_realm.id
+  client_id           = each.value.id
+  name                = "group-mapper"
+  claim_name          = "groups"
+  full_path           = false
+  add_to_id_token     = true
+  add_to_access_token = true
 }
 
-# 5. Secret Storage in Vault
-resource "vault_generic_secret" "oidc_clients" {
+# Audience Mapper for Vault to verify Token
+resource "keycloak_openid_audience_protocol_mapper" "vault_audience" {
+  realm_id  = keycloak_realm.infra_realm.id
+  client_id = keycloak_openid_client.clients["vault"].id
+  name      = "audience-mapper"
+
+  included_custom_audience = "vault-infra"
+  add_to_id_token          = true
+  add_to_access_token      = true
+}
+
+# 5. Secret Storage in Vault (Using V2 for proper path handling)
+resource "vault_kv_secret_v2" "oidc_clients" {
   provider = vault.production
   for_each = keycloak_openid_client.clients
-  path     = "secret/on-premise-gitlab-deployment/oidc/clients/${each.key}"
+  mount    = "secret"
+  name     = "on-premise-gitlab-deployment/oidc/clients/${each.key}"
 
   data_json = jsonencode({
     client_id     = each.value.client_id
     client_secret = random_password.client_secrets[each.key].result
     issuer        = "https://sso.keycloak.production.iac.internal/realms/${local.realm_id}"
   })
+}
+
+# 6. Test User & Groups for OIDC Verification
+resource "keycloak_group" "admin_group" {
+  realm_id = keycloak_realm.infra_realm.id
+  name     = "admin" # Matches the Vault alias 'admin'
+}
+
+resource "keycloak_user" "test_admin" {
+  realm_id       = keycloak_realm.infra_realm.id
+  username       = "testadmin"
+  enabled        = true
+  email          = "testadmin@iac.internal"
+  first_name     = "Test"
+  last_name      = "Admin"
+  email_verified = true
+
+  initial_password {
+    value     = "testadmin"
+    temporary = false
+  }
+}
+
+resource "keycloak_user_groups" "test_admin_groups" {
+  realm_id = keycloak_realm.infra_realm.id
+  user_id  = keycloak_user.test_admin.id
+
+  group_ids = [
+    keycloak_group.admin_group.id
+  ]
 }

--- a/terraform/layers/40-provision-keycloak-oidc/main.tf
+++ b/terraform/layers/40-provision-keycloak-oidc/main.tf
@@ -27,8 +27,8 @@ resource "random_password" "client_secrets" {
 resource "keycloak_openid_client" "clients" {
   for_each = {
     vault = {
-      client_id           = "vault-infra"
-      name                = "Vault Infrastructure"
+      client_id = "vault-infra"
+      name      = "Vault Infrastructure"
       valid_redirect_uris = [
         "https://vault.production.iac.internal/ui/vault/auth/oidc/oidc/callback",
         "https://vault.production.iac.internal/ui/vault/auth/oidc/callback",
@@ -102,32 +102,47 @@ resource "vault_kv_secret_v2" "oidc_clients" {
   })
 }
 
-# 6. Test User & Groups for OIDC Verification
-resource "keycloak_group" "admin_group" {
-  realm_id = keycloak_realm.infra_realm.id
-  name     = "admin" # Matches the Vault alias 'admin'
+# 6. Test User & Groups Configuration
+locals {
+  all_groups = distinct(flatten([for u in var.oidc_users : u.groups]))
 }
 
-resource "keycloak_user" "test_admin" {
-  realm_id       = keycloak_realm.infra_realm.id
-  username       = "testadmin"
-  enabled        = true
-  email          = "testadmin@iac.internal"
-  first_name     = "Test"
-  last_name      = "Admin"
-  email_verified = true
+resource "keycloak_group" "groups" {
+  for_each = toset(local.all_groups)
+  realm_id = keycloak_realm.infra_realm.id
+  name     = each.key
 
-  initial_password {
-    value     = "testadmin"
-    temporary = false
+  lifecycle {
+    prevent_destroy = false # Set to true in production if needed
   }
 }
 
-resource "keycloak_user_groups" "test_admin_groups" {
+resource "keycloak_user" "users" {
+  for_each       = var.oidc_users
+  realm_id       = keycloak_realm.infra_realm.id
+  username       = each.value.username
+  enabled        = true
+  email          = each.value.email
+  first_name     = each.value.first_name
+  last_name      = each.value.last_name
+  email_verified = true
+
+  initial_password {
+    value     = each.value.password
+    temporary = false
+  }
+
+  lifecycle {
+    ignore_changes = [initial_password]
+  }
+}
+
+resource "keycloak_user_groups" "user_assignments" {
+  for_each = var.oidc_users
   realm_id = keycloak_realm.infra_realm.id
-  user_id  = keycloak_user.test_admin.id
+  user_id  = keycloak_user.users[each.key].id
 
   group_ids = [
-    keycloak_group.admin_group.id
+    for g in each.value.groups : keycloak_group.groups[g].id
   ]
 }

--- a/terraform/layers/40-provision-keycloak-oidc/main.tf
+++ b/terraform/layers/40-provision-keycloak-oidc/main.tf
@@ -18,7 +18,7 @@ resource "keycloak_realm" "infra_realm" {
 
 # 2. Client Secret Generation
 resource "random_password" "client_secrets" {
-  for_each = toset(["vault", "gitlab", "harbor", "minio"])
+  for_each = toset(["vault_frontend", "gitlab_frontend", "harbor_frontend", "gitlab_minio", "harbor_minio"])
   length   = 32
   special  = false
 }
@@ -26,30 +26,35 @@ resource "random_password" "client_secrets" {
 # 3. OIDC Clients
 resource "keycloak_openid_client" "clients" {
   for_each = {
-    vault = {
+    vault_frontend = {
       client_id = "vault-infra"
       name      = "Vault Infrastructure"
       valid_redirect_uris = [
-        "https://vault.production.iac.internal/ui/vault/auth/oidc/oidc/callback",
-        "https://vault.production.iac.internal/ui/vault/auth/oidc/callback",
-        "https://vault.production.iac.internal/vault/oidc/callback",
+        "${local.vault_frontend_url}/ui/vault/auth/oidc/oidc/callback",
+        "${local.vault_frontend_url}/ui/vault/auth/oidc/callback",
+        "${local.vault_frontend_url}/vault/oidc/callback",
         "http://localhost:8250/oidc/callback"
       ]
     }
-    gitlab = {
+    gitlab_frontend = {
       client_id           = "gitlab-infra"
       name                = "GitLab Platform"
-      valid_redirect_uris = ["https://gitlab.production.iac.internal/users/auth/openid_connect/callback"]
+      valid_redirect_uris = ["${local.gitlab_frontend_url}/users/auth/openid_connect/callback"]
     }
-    harbor = {
+    harbor_frontend = {
       client_id           = "harbor-infra"
       name                = "Harbor Registry"
-      valid_redirect_uris = ["https://harbor.production.iac.internal/c/oidc/callback"]
+      valid_redirect_uris = ["${local.harbor_frontend_url}/c/oidc/callback"]
     }
-    minio = {
-      client_id           = "minio-infra"
-      name                = "MinIO Console"
-      valid_redirect_uris = ["https://minio.gitlab.production.iac.internal/oauth_callback"]
+    gitlab_minio = {
+      client_id           = "gitlab-minio-infra"
+      name                = "GitLab MinIO Console"
+      valid_redirect_uris = ["${local.gitlab_minio_url}/oauth_callback"]
+    }
+    harbor_minio = {
+      client_id           = "harbor-minio-infra"
+      name                = "Harbor MinIO Console"
+      valid_redirect_uris = ["${local.harbor_minio_url}/oauth_callback"]
     }
   }
 
@@ -80,7 +85,7 @@ resource "keycloak_openid_group_membership_protocol_mapper" "group_mapper" {
 # Audience Mapper for Vault to verify Token
 resource "keycloak_openid_audience_protocol_mapper" "vault_audience" {
   realm_id  = keycloak_realm.infra_realm.id
-  client_id = keycloak_openid_client.clients["vault"].id
+  client_id = keycloak_openid_client.clients["vault_frontend"].id
   name      = "audience-mapper"
 
   included_custom_audience = "vault-infra"
@@ -98,7 +103,7 @@ resource "vault_kv_secret_v2" "oidc_clients" {
   data_json = jsonencode({
     client_id     = each.value.client_id
     client_secret = random_password.client_secrets[each.key].result
-    issuer        = "https://sso.keycloak.production.iac.internal/realms/${local.realm_id}"
+    issuer        = "${local.keycloak_frontend_url}/realms/${local.realm_id}"
   })
 }
 

--- a/terraform/layers/40-provision-keycloak-oidc/main.tf
+++ b/terraform/layers/40-provision-keycloak-oidc/main.tf
@@ -1,0 +1,84 @@
+
+# 1. Realm Configuration
+resource "keycloak_realm" "infra_realm" {
+  realm             = local.realm_id
+  enabled           = true
+  display_name      = "Infrastructure Centralized Identity"
+  display_name_html = "<b>Infrastructure Centralized Identity</b>"
+
+  login_with_email_allowed = true
+  reset_password_allowed   = true
+  remember_me              = true
+
+  internationalization {
+    supported_locales = ["en", "zh-CN"]
+    default_locale    = "en"
+  }
+}
+
+# 2. Client Secret Generation
+resource "random_password" "client_secrets" {
+  for_each = toset(["vault", "gitlab", "harbor", "minio"])
+  length   = 32
+  special  = false
+}
+
+# 3. OIDC Clients
+resource "keycloak_openid_client" "clients" {
+  for_each = {
+    vault = {
+      client_id           = "vault-infra"
+      name                = "Vault Infrastructure"
+      valid_redirect_uris = ["https://vault.production.iac.internal/ui/vault/auth/oidc/oidc/callback"]
+    }
+    gitlab = {
+      client_id           = "gitlab-infra"
+      name                = "GitLab Platform"
+      valid_redirect_uris = ["https://gitlab.production.iac.internal/users/auth/openid_connect/callback"]
+    }
+    harbor = {
+      client_id           = "harbor-infra"
+      name                = "Harbor Registry"
+      valid_redirect_uris = ["https://harbor.production.iac.internal/c/oidc/callback"]
+    }
+    minio = {
+      client_id           = "minio-infra"
+      name                = "MinIO Console"
+      valid_redirect_uris = ["https://minio.gitlab.production.iac.internal/oauth_callback"]
+    }
+  }
+
+  realm_id              = keycloak_realm.infra_realm.id
+  client_id             = each.value.client_id
+  name                  = each.value.name
+  enabled               = true
+  access_type           = "CONFIDENTIAL"
+  client_secret         = random_password.client_secrets[each.key].result
+  standard_flow_enabled = true
+
+  valid_redirect_uris = each.value.valid_redirect_uris
+  web_origins         = ["+"]
+}
+
+# 4. Protocol Mappers (Inject Groups into Token)
+resource "keycloak_openid_group_membership_protocol_mapper" "group_mapper" {
+  for_each   = keycloak_openid_client.clients
+  realm_id   = keycloak_realm.infra_realm.id
+  client_id  = each.value.id
+  name       = "group-mapper"
+  claim_name = "groups"
+  full_path  = false
+}
+
+# 5. Secret Storage in Vault
+resource "vault_generic_secret" "oidc_clients" {
+  provider = vault.production
+  for_each = keycloak_openid_client.clients
+  path     = "secret/on-premise-gitlab-deployment/oidc/clients/${each.key}"
+
+  data_json = jsonencode({
+    client_id     = each.value.client_id
+    client_secret = random_password.client_secrets[each.key].result
+    issuer        = "https://sso.keycloak.production.iac.internal/realms/${local.realm_id}"
+  })
+}

--- a/terraform/layers/40-provision-keycloak-oidc/main.tf
+++ b/terraform/layers/40-provision-keycloak-oidc/main.tf
@@ -31,6 +31,8 @@ resource "keycloak_openid_client" "clients" {
       name                = "Vault Infrastructure"
       valid_redirect_uris = [
         "https://vault.production.iac.internal/ui/vault/auth/oidc/oidc/callback",
+        "https://vault.production.iac.internal/ui/vault/auth/oidc/callback",
+        "https://vault.production.iac.internal/vault/oidc/callback",
         "http://localhost:8250/oidc/callback"
       ]
     }

--- a/terraform/layers/40-provision-keycloak-oidc/outputs.tf
+++ b/terraform/layers/40-provision-keycloak-oidc/outputs.tf
@@ -7,7 +7,7 @@ output "oidc_clients" {
   value = {
     for k, v in keycloak_openid_client.clients : k => {
       client_id   = v.client_id
-      secret_path = vault_generic_secret.oidc_clients[k].path
+      secret_path = vault_kv_secret_v2.oidc_clients[k].path
     }
   }
 }

--- a/terraform/layers/40-provision-keycloak-oidc/outputs.tf
+++ b/terraform/layers/40-provision-keycloak-oidc/outputs.tf
@@ -1,0 +1,17 @@
+
+output "realm_id" {
+  value = keycloak_realm.infra_realm.id
+}
+
+output "oidc_clients" {
+  value = {
+    for k, v in keycloak_openid_client.clients : k => {
+      client_id   = v.client_id
+      secret_path = vault_generic_secret.oidc_clients[k].path
+    }
+  }
+}
+
+output "issuer_url" {
+  value = "https://sso.keycloak.production.iac.internal/realms/${local.realm_id}"
+}

--- a/terraform/layers/40-provision-keycloak-oidc/outputs.tf
+++ b/terraform/layers/40-provision-keycloak-oidc/outputs.tf
@@ -1,17 +1,12 @@
-
-output "realm_id" {
-  value = keycloak_realm.infra_realm.id
+output "issuer_url" {
+  value = "${local.keycloak_frontend_url}/realms/${local.realm_id}"
 }
 
 output "oidc_clients" {
-  value = {
-    for k, v in keycloak_openid_client.clients : k => {
-      client_id   = v.client_id
-      secret_path = vault_kv_secret_v2.oidc_clients[k].path
-    }
-  }
+  value     = keycloak_openid_client.clients
+  sensitive = true
 }
 
-output "issuer_url" {
-  value = "https://sso.keycloak.production.iac.internal/realms/${local.realm_id}"
+output "vault_redirect_uris" {
+  value = local.vault_redirect_uris
 }

--- a/terraform/layers/40-provision-keycloak-oidc/providers.tf
+++ b/terraform/layers/40-provision-keycloak-oidc/providers.tf
@@ -18,7 +18,7 @@ terraform {
 
 provider "vault" {
   alias        = "production"
-  address      = local.vault_address
+  address      = local.vault_frontend_url
   ca_cert_file = local.state.vault_pki.bootstrap_ca_b64.path
 
   auth_login {
@@ -35,7 +35,7 @@ provider "keycloak" {
   client_id           = "admin-cli"
   username            = local.keycloak_admin_user
   password            = local.keycloak_admin_password
-  url                 = local.keycloak_url
+  url                 = local.keycloak_frontend_url
   root_ca_certificate = base64decode(local.state.vault_pki.bootstrap_ca_b64.content_b64)
   initial_login       = false
 }

--- a/terraform/layers/40-provision-keycloak-oidc/providers.tf
+++ b/terraform/layers/40-provision-keycloak-oidc/providers.tf
@@ -1,0 +1,41 @@
+
+terraform {
+  required_providers {
+    keycloak = {
+      source  = "keycloak/keycloak"
+      version = "5.7.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "5.5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.6.3"
+    }
+  }
+}
+
+provider "vault" {
+  alias        = "production"
+  address      = local.vault_address
+  ca_cert_file = local.state.vault_pki.bootstrap_ca_b64.path
+
+  auth_login {
+    path = "auth/approle/login"
+    parameters = {
+      role_id   = local.state.vault_prod_bootstrap.production_role_id
+      secret_id = local.state.vault_prod_bootstrap.production_secret_id
+    }
+  }
+  skip_child_token = true
+}
+
+provider "keycloak" {
+  client_id           = "admin-cli"
+  username            = local.keycloak_admin_user
+  password            = local.keycloak_admin_password
+  url                 = local.keycloak_url
+  root_ca_certificate = base64decode(local.state.vault_pki.bootstrap_ca_b64.content_b64)
+  initial_login       = false
+}

--- a/terraform/layers/40-provision-keycloak-oidc/terraform.tfvars.example
+++ b/terraform/layers/40-provision-keycloak-oidc/terraform.tfvars.example
@@ -1,0 +1,11 @@
+
+oidc_users = {
+  "admin" = {
+    username   = "testadmin"
+    email      = "testadmin@iac.internal"
+    first_name = "System"
+    last_name  = "Administrator"
+    password   = "testadmin"
+    groups     = ["admin", "infra-admins"]
+  },
+}

--- a/terraform/layers/40-provision-keycloak-oidc/variables.tf
+++ b/terraform/layers/40-provision-keycloak-oidc/variables.tf
@@ -1,0 +1,13 @@
+
+variable "oidc_users" {
+  description = "Map of users to create in Keycloak with their associated groups"
+  type = map(object({
+    username   = string
+    email      = string
+    first_name = string
+    last_name  = string
+    password   = string
+    groups     = list(string)
+  }))
+  default = {}
+}

--- a/terraform/layers/45-security-vault-oidc/.terraform.lock.hcl
+++ b/terraform/layers/45-security-vault-oidc/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/vault" {
+  version     = "5.5.0"
+  constraints = "5.5.0"
+  hashes = [
+    "h1:L1pyXCClhJC/u9ye/HO1HDnjgODn5df8dp1BBFgrvUU=",
+    "zh:2e582d3804206c64b19c18afa95618cd5b041ed102b5fb62ca19c756d2930e70",
+    "zh:402c72251454905ef72e34bbd26af9144cff72ce3887a06ea2da95cc31a37d26",
+    "zh:552a5c521abd77015787030dbf55fc85b108f3c11fcd0f75d1b29175ff44c74d",
+    "zh:5a5e5743e25e72dd1bb20e72ecc7767ebc37b42c5608bc0f4bb6519488adff18",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7d59a0eb34594043656959b0cccb0cf79c973e2633e764e5e7f859ca515f81da",
+    "zh:86f74f759a1bf721db55b874b96eb2c5553aae12e56926724a398ef50631b43c",
+    "zh:c37d43b71b2d9352fefbed14bc32ab6c4bf607fdb3fe1a2fa7044630f94296e9",
+    "zh:c6fa4d9bf3e2f84ffef5e27782c2be6166a4eb6c068de586839198baf9428044",
+    "zh:c983cec46278cc28fc6449ef6a2013b5bc10821e10856056f0d4ae0f9830fd16",
+    "zh:e7ab6e63e95e820780462f1df122629733114f6196b5bef5a64efe019c25a3fe",
+    "zh:f1a9ecb68f71bcddb5bd1ec2716bac14d19f0931faa4a46d9270d89028271e69",
+  ]
+}

--- a/terraform/layers/45-security-vault-oidc/data.tf
+++ b/terraform/layers/45-security-vault-oidc/data.tf
@@ -38,5 +38,5 @@ data "terraform_remote_state" "keycloak_provisioning" {
 data "vault_kv_secret_v2" "keycloak_vault_client" {
   provider = vault.production
   mount    = "secret"
-  name     = "on-premise-gitlab-deployment/oidc/clients/vault"
+  name     = "on-premise-gitlab-deployment/oidc/clients/vault_frontend"
 }

--- a/terraform/layers/45-security-vault-oidc/data.tf
+++ b/terraform/layers/45-security-vault-oidc/data.tf
@@ -1,0 +1,42 @@
+
+data "terraform_remote_state" "metadata" {
+  backend = "local"
+  config = {
+    path = "../00-foundation-metadata/terraform.tfstate"
+  }
+}
+
+data "terraform_remote_state" "vault_sys" {
+  backend = "local"
+  config = {
+    path = "../15-shared-vault-frontend/terraform.tfstate"
+  }
+}
+
+data "terraform_remote_state" "vault_prod_bootstrap" {
+  backend = "local"
+  config = {
+    path = "../20-security-vault-approle/terraform.tfstate"
+  }
+}
+
+data "terraform_remote_state" "vault_pki" {
+  backend = "local"
+  config = {
+    path = "../25-security-pki/terraform.tfstate"
+  }
+}
+
+data "terraform_remote_state" "keycloak_provisioning" {
+  backend = "local"
+  config = {
+    path = "../40-provision-keycloak-oidc/terraform.tfstate"
+  }
+}
+
+# Read OIDC Client credentials from Vault (Created in L40)
+data "vault_kv_secret_v2" "keycloak_vault_client" {
+  provider = vault.production
+  mount    = "secret"
+  name     = "on-premise-gitlab-deployment/oidc/clients/vault"
+}

--- a/terraform/layers/45-security-vault-oidc/locals.tf
+++ b/terraform/layers/45-security-vault-oidc/locals.tf
@@ -1,0 +1,17 @@
+
+locals {
+  state = {
+    metadata             = data.terraform_remote_state.metadata.outputs
+    vault_sys            = data.terraform_remote_state.vault_sys.outputs
+    vault_pki            = data.terraform_remote_state.vault_pki.outputs
+    vault_prod_bootstrap = data.terraform_remote_state.vault_prod_bootstrap.outputs
+    keycloak_oidc        = data.terraform_remote_state.keycloak_provisioning.outputs
+  }
+
+  vault_address = "https://${local.state.vault_sys.service_vip}:443"
+  
+  # OIDC Configuration
+  oidc_discovery_url = local.state.keycloak_oidc.issuer_url
+  oidc_client_id     = data.vault_kv_secret_v2.keycloak_vault_client.data["client_id"]
+  oidc_client_secret = data.vault_kv_secret_v2.keycloak_vault_client.data["client_secret"]
+}

--- a/terraform/layers/45-security-vault-oidc/main.tf
+++ b/terraform/layers/45-security-vault-oidc/main.tf
@@ -30,12 +30,7 @@ resource "vault_jwt_auth_backend_role" "keycloak_user" {
   role_type            = "oidc"
   verbose_oidc_logging = true
 
-  allowed_redirect_uris = [
-    "https://vault.production.iac.internal/ui/vault/auth/oidc/oidc/callback",
-    "https://vault.production.iac.internal/ui/vault/auth/oidc/callback",
-    "https://vault.production.iac.internal/vault/oidc/callback",
-    "http://localhost:8250/oidc/callback"
-  ]
+  allowed_redirect_uris = local.state.keycloak_oidc.vault_redirect_uris
 }
 
 # 3. Identity Groups (External) - Dynamic Mapping for all Management Roles

--- a/terraform/layers/45-security-vault-oidc/main.tf
+++ b/terraform/layers/45-security-vault-oidc/main.tf
@@ -21,13 +21,14 @@ resource "vault_jwt_auth_backend" "keycloak" {
 # This role allows everyone from Keycloak to authenticate; actual permissions
 # are managed via Identity Group mappings based on the 'groups' claim.
 resource "vault_jwt_auth_backend_role" "keycloak_user" {
-  provider       = vault.production
-  backend        = vault_jwt_auth_backend.keycloak.path
-  role_name      = "keycloak-user"
-  token_policies = ["default"]
-  user_claim     = "sub"
-  groups_claim   = "groups"
-  role_type      = "oidc"
+  provider             = vault.production
+  backend              = vault_jwt_auth_backend.keycloak.path
+  role_name            = "keycloak-user"
+  token_policies       = ["default"]
+  user_claim           = "preferred_username"
+  groups_claim         = "groups"
+  role_type            = "oidc"
+  verbose_oidc_logging = true
 
   allowed_redirect_uris = [
     "https://vault.production.iac.internal/ui/vault/auth/oidc/oidc/callback",

--- a/terraform/layers/45-security-vault-oidc/main.tf
+++ b/terraform/layers/45-security-vault-oidc/main.tf
@@ -32,6 +32,8 @@ resource "vault_jwt_auth_backend_role" "keycloak_user" {
 
   allowed_redirect_uris = [
     "https://vault.production.iac.internal/ui/vault/auth/oidc/oidc/callback",
+    "https://vault.production.iac.internal/ui/vault/auth/oidc/callback",
+    "https://vault.production.iac.internal/vault/oidc/callback",
     "http://localhost:8250/oidc/callback"
   ]
 }

--- a/terraform/layers/45-security-vault-oidc/main.tf
+++ b/terraform/layers/45-security-vault-oidc/main.tf
@@ -1,0 +1,61 @@
+
+# 1. Enable OIDC Auth Backend
+resource "vault_jwt_auth_backend" "keycloak" {
+  provider              = vault.production
+  description           = "OIDC Auth Backend for Keycloak"
+  path                  = "oidc"
+  type                  = "oidc"
+  oidc_discovery_url    = local.oidc_discovery_url
+  oidc_discovery_ca_pem = base64decode(local.state.vault_pki.bootstrap_ca_b64.content_b64)
+  oidc_client_id        = local.oidc_client_id
+  oidc_client_secret    = local.oidc_client_secret
+
+  tune {
+    listing_visibility = "unauth"
+    default_lease_ttl  = "1h"
+    max_lease_ttl      = "24h"
+  }
+}
+
+# 2. Configure Unified OIDC Role
+# This role allows everyone from Keycloak to authenticate; actual permissions
+# are managed via Identity Group mappings based on the 'groups' claim.
+resource "vault_jwt_auth_backend_role" "keycloak_user" {
+  provider       = vault.production
+  backend        = vault_jwt_auth_backend.keycloak.path
+  role_name      = "keycloak-user"
+  token_policies = ["default"]
+  user_claim     = "sub"
+  groups_claim   = "groups"
+  role_type      = "oidc"
+
+  allowed_redirect_uris = [
+    "https://vault.production.iac.internal/ui/vault/auth/oidc/oidc/callback",
+    "http://localhost:8250/oidc/callback"
+  ]
+}
+
+# 3. Identity Groups (External) - Dynamic Mapping for all Management Roles
+resource "vault_identity_group" "management_groups" {
+  provider = vault.production
+  for_each = local.state.vault_pki.management_policies
+
+  name     = "keycloak-${replace(each.key, "oidc-", "")}s" # e.g. keycloak-admins, keycloak-auditors
+  type     = "external"
+  policies = [each.value]
+
+  metadata = {
+    source = "keycloak"
+  }
+}
+
+# 4. Group Aliases - Linking Keycloak groups to Vault groups
+resource "vault_identity_group_alias" "management_group_aliases" {
+  provider = vault.production
+  for_each = local.state.vault_pki.management_policies
+
+  # Keycloak group name (Assuming groups in Keycloak are named 'admin', 'auditor', 'developer')
+  name           = replace(each.key, "oidc-", "")
+  mount_accessor = vault_jwt_auth_backend.keycloak.accessor
+  canonical_id   = vault_identity_group.management_groups[each.key].id
+}

--- a/terraform/layers/45-security-vault-oidc/outputs.tf
+++ b/terraform/layers/45-security-vault-oidc/outputs.tf
@@ -1,0 +1,16 @@
+
+output "auth_backend_path" {
+  value = vault_jwt_auth_backend.keycloak.path
+}
+
+output "auth_backend_accessor" {
+  value = vault_jwt_auth_backend.keycloak.accessor
+}
+
+output "oidc_role" {
+  value = vault_jwt_auth_backend_role.keycloak_user.role_name
+}
+
+output "login_url" {
+  value = "https://vault.production.iac.internal/ui/vault/auth/oidc"
+}

--- a/terraform/layers/45-security-vault-oidc/providers.tf
+++ b/terraform/layers/45-security-vault-oidc/providers.tf
@@ -1,0 +1,24 @@
+
+terraform {
+  required_providers {
+    vault = {
+      source  = "hashicorp/vault"
+      version = "5.5.0"
+    }
+  }
+}
+
+provider "vault" {
+  alias        = "production"
+  address      = local.vault_address
+  ca_cert_file = local.state.vault_pki.bootstrap_ca_b64.path
+
+  auth_login {
+    path = "auth/approle/login"
+    parameters = {
+      role_id   = local.state.vault_prod_bootstrap.production_role_id
+      secret_id = local.state.vault_prod_bootstrap.production_secret_id
+    }
+  }
+  skip_child_token = true
+}

--- a/terraform/layers/60-provision-harbor/data.tf
+++ b/terraform/layers/60-provision-harbor/data.tf
@@ -36,5 +36,5 @@ data "vault_kv_secret_v2" "harbor_vars" {
 data "vault_kv_secret_v2" "keycloak_harbor_client" {
   provider = vault.production
   mount    = "secret"
-  name     = "on-premise-gitlab-deployment/oidc/clients/harbor"
+  name     = "on-premise-gitlab-deployment/oidc/clients/harbor_frontend"
 }

--- a/terraform/layers/60-provision-harbor/data.tf
+++ b/terraform/layers/60-provision-harbor/data.tf
@@ -20,8 +20,21 @@ data "terraform_remote_state" "vault_pki" {
   }
 }
 
+data "terraform_remote_state" "keycloak_oidc" {
+  backend = "local"
+  config = {
+    path = "../40-provision-keycloak-oidc/terraform.tfstate"
+  }
+}
+
 data "vault_kv_secret_v2" "harbor_vars" {
   provider = vault.production
   mount    = "secret"
   name     = "on-premise-gitlab-deployment/harbor/app"
+}
+
+data "vault_kv_secret_v2" "keycloak_harbor_client" {
+  provider = vault.production
+  mount    = "secret"
+  name     = "on-premise-gitlab-deployment/oidc/clients/harbor"
 }

--- a/terraform/layers/60-provision-harbor/locals.tf
+++ b/terraform/layers/60-provision-harbor/locals.tf
@@ -24,6 +24,6 @@ locals {
 # 4. OIDC Configuration Context
 locals {
   oidc_discovery_url = local.state.keycloak_oidc.issuer_url
-  oidc_client_id     = local.state.keycloak_oidc.oidc_clients["harbor"].client_id
+  oidc_client_id     = local.state.keycloak_oidc.oidc_clients["harbor_frontend"].client_id
   oidc_client_secret = data.vault_kv_secret_v2.keycloak_harbor_client.data["client_secret"]
 }

--- a/terraform/layers/60-provision-harbor/locals.tf
+++ b/terraform/layers/60-provision-harbor/locals.tf
@@ -5,6 +5,7 @@ locals {
     metadata             = data.terraform_remote_state.metadata.outputs
     vault_pki            = data.terraform_remote_state.vault_pki.outputs
     vault_prod_bootstrap = data.terraform_remote_state.vault_prod_bootstrap.outputs
+    keycloak_oidc        = data.terraform_remote_state.keycloak_oidc.outputs
   }
 }
 
@@ -18,4 +19,11 @@ locals {
 locals {
   harbor_hostname       = local.state.metadata.global_pki_map["harbor-frontend"].dns_san[0]
   harbor_admin_password = data.vault_kv_secret_v2.harbor_vars.data["harbor_admin_password"]
+}
+
+# 4. OIDC Configuration Context
+locals {
+  oidc_discovery_url = local.state.keycloak_oidc.issuer_url
+  oidc_client_id     = local.state.keycloak_oidc.oidc_clients["harbor"].client_id
+  oidc_client_secret = data.vault_kv_secret_v2.keycloak_harbor_client.data["client_secret"]
 }

--- a/terraform/layers/60-provision-harbor/main.tf
+++ b/terraform/layers/60-provision-harbor/main.tf
@@ -2,3 +2,30 @@
 module "harbor_system_config" {
   source = "../../modules/configuration/harbor-system-config"
 }
+
+# 1. Harbor OIDC Authentication Configuration
+resource "harbor_config_auth" "main" {
+  auth_mode          = "oidc_auth"
+  primary_auth_mode  = true
+  oidc_name          = "Keycloak"
+  oidc_endpoint      = local.oidc_discovery_url
+  oidc_client_id     = local.oidc_client_id
+  oidc_client_secret = local.oidc_client_secret
+  oidc_scope         = "openid,profile,email"
+  oidc_verify_cert   = true
+  oidc_auto_onboard  = true
+  oidc_user_claim    = "preferred_username"
+  oidc_groups_claim  = "groups"
+
+  # Map the Keycloak 'admin' group to Harbor System Administrator
+  oidc_admin_group = "admin"
+}
+
+# 2. External OIDC Groups (Dynamic Mapping from L25 Management Roles)
+# This creates the group identities in Harbor that can be assigned to projects.
+resource "harbor_group" "oidc_groups" {
+  for_each = local.state.vault_pki.management_policies
+
+  group_name = replace(each.key, "oidc-", "") # e.g. admin, auditor, developer
+  group_type = 3                              # 3 = OIDC Group
+}

--- a/terraform/modules/configuration/vault-workload-identity/outputs.tf
+++ b/terraform/modules/configuration/vault-workload-identity/outputs.tf
@@ -20,3 +20,8 @@ output "approle_name" {
   value       = vault_approle_auth_backend_role.this.role_name
 }
 
+
+output "policy_name" {
+  description = "The name of the generated ACL policy"
+  value       = vault_policy.this.name
+}


### PR DESCRIPTION
## Summary

This PR integrates Keycloak as the unified Identity Provider (IdP) with Vault and Harbor. It includes reorganizing ACL policies for `L20` and `L25`, and explicitly adding all frontend service names to the PKI certificate SANs and CoreDNS Address records.

## Changes

### Core Architecture

1. **Unified Identity Mapping (L45/L60)**: Implemented the "Keycloak login, decentralized authorization" mechanism. Automatically maps the Keycloak `groups` claim to Vault external identity policies and Harbor OIDC groups. Currently, both Vault Frontend and Harbor Frontend support OIDC login.
2. **Infrastructure PKI Alignment (L00/L05)**: Included all frontend service domains (e.g., `sso.keycloak...`) into PKI SANs and core DNS resolution to ensure internal communication aligns with production TLS verification paths.
3. **Symmetric PBR Routing (Ansible/CLB)**: Refactored the load balancer PBR priority logic (`Priority 5` -> `200`) and precisely injected L2 shortcut routes into the VIP exclusive routing table.

### Fixes & Technical Debt

- **Networking: TLS Handshake Timeout**:
    - _Problem_: The legacy global PBR rule (`Priority 5`) caused Harbor nodes to use the default gateway when connecting to Keycloak without `advmss` settings, leading to certificate packet drops due to `VXLAN` `MTU` limits.
    - _Solution_: Injected specific VIP routes including `advmss 1360` into Harbor nodes and corrected the Ansible interface detection logic to exclude Calico virtual interfaces.

- **Harbor Authentication: Invalid Scope**:
    - _Problem_: The Harbor OIDC configuration incorrectly requested the `groups` scope, causing Keycloak to refuse token issuance.
    - _Solution_: Removed redundant scope requests and switched to using a `Protocol Mapper` to inject the `groups` claim into the token.

### Refactoring

- **Workload Identity (L20)**: Reorganized and converged `AppRole` ACL permissions from `L25`, ensuring workload identities have the least privilege to read OIDC Client Secrets and Backend Accessor, with ACLs unified into `L20`.
- **Policy Management**: Decoupled identity group mapping logic from the PKI management layer by using `vault_identity_group_alias` for dynamic processing, improving flexibility for future service extensions.

### Verification

- [x] **Cluster Status**: Verified Keycloak and Vault cluster health and Raft node synchronization.
- [x] **SSO Flow**: Manually tested "Login with OIDC" for Harbor and Vault, confirming automatic onboarding and correct policy assignment.
- [x] **VIP Access**: Verified that Harbor Core Pod can stably access the Keycloak VIP (`172.16.142.250`) via domain name.
- [x] **Idempotency**: Executed `terraform apply` and `Ansible Playbook` multiple times to confirm no state conflicts in routing tables and authentication configs.
