### PR TITLE
feat(vault): Upgrade Bootstrapper and Production Vault to `2.0`.

### DIFF
--- a/ansible/group_vars/all/1x-vault_common.yaml
+++ b/ansible/group_vars/all/1x-vault_common.yaml
@@ -1,7 +1,7 @@
 ---
 vault_target_os: "linux"
 vault_target_arch: "amd64"
-vault_target_version: "1.21.1"
+vault_target_version: "2.0.1"
 
 # Load Balancer
 haproxy_stats_port: 8404

--- a/ansible/roles/07-base-vault/tasks/main.yaml
+++ b/ansible/roles/07-base-vault/tasks/main.yaml
@@ -31,7 +31,10 @@
         mode: "0755"
         owner: root
         group: root
-      when: vault_installed_version.rc != 0 or vault_target_version not in vault_installed_version.stdout
+      when: >-
+        vault_installed_version.rc != 0 or
+        vault_target_version not in
+        (vault_installed_version.stdout | default('')).split() | map('replace', 'v', '')
 
     - name: "Step B2. Verify Vault installation"
       ansible.builtin.command: vault --version

--- a/ansible/roles/07-base-vault/tasks/main.yaml
+++ b/ansible/roles/07-base-vault/tasks/main.yaml
@@ -15,6 +15,12 @@
 - name: "Block B: Install Vault Binary"
   become: true
   block:
+    - name: "Step B0. Check installed Vault version"
+      ansible.builtin.command: vault version
+      register: vault_installed_version
+      changed_when: false
+      failed_when: false
+
     - name: "Step B1. Download and Unarchive Vault (v{{ vault_target_version }})"
       vars:
         vault_zip: "vault_{{ vault_target_version }}_{{ vault_target_os }}_{{ vault_target_arch }}.zip"
@@ -25,7 +31,7 @@
         mode: "0755"
         owner: root
         group: root
-        creates: "/usr/local/bin/vault"
+      when: vault_installed_version.rc != 0 or vault_target_version not in vault_installed_version.stdout
 
     - name: "Step B2. Verify Vault installation"
       ansible.builtin.command: vault --version

--- a/compose.yml
+++ b/compose.yml
@@ -5,14 +5,15 @@ x-podman:
 services:
   # Service 1: Vault Server (Target System)
   iac-vault-server:
-    image: docker.io/hashicorp/vault:1.20.2
+    image: docker.io/hashicorp/vault:2.0
     container_name: iac-vault-server
     entrypoint: "vault"
-    command: server -config=/vault/vault.hcl
+    command: server -config=/opt/vault/vault.hcl
     volumes:
-      - ./vault/vault.hcl:/vault/vault.hcl:z
-      - ./vault/data:/vault/data:z
-      - ./vault/tls:/vault/tls:z
+      - ./vault/vault.hcl:/opt/vault/vault.hcl:z
+      - ./vault/data:/opt/vault/data:z
+      - ./vault/tls:/opt/vault/tls:z
+    user: "${HOST_UID}:${HOST_GID}"
     cap_add:
       - IPC_LOCK
     network_mode: "host"
@@ -21,7 +22,11 @@ services:
       - SKIP_SETCAP=true
       - VAULT_ADDR=https://127.0.0.1:8200
     healthcheck:
-      test: ["CMD-SHELL", "vault status -address=https://127.0.0.1:8200 -tls-skip-verify || if [ $? -eq 2 ]; then exit 0; else exit 1; fi"]
+      test:
+        [
+          "CMD-SHELL",
+          "vault status -address=https://127.0.0.1:8200 -tls-skip-verify || if [ $? -eq 2 ]; then exit 0; else exit 1; fi",
+        ]
       interval: 5s
       timeout: 3s
       retries: 5

--- a/terraform/layers/25-security-pki/terraform.tfvars.example
+++ b/terraform/layers/25-security-pki/terraform.tfvars.example
@@ -3,6 +3,6 @@ environment = "development"
 
 vault_pki_engine_config = {
   path                      = "pki/prod"
-  default_lease_ttl_seconds = 60 * 60 * 24      # 1 Day
+  default_lease_ttl_seconds = 60 * 60 * 24 * 7  # 7 Days
   max_lease_ttl_seconds     = 60 * 60 * 24 * 45 # 45 Days
 }

--- a/vault/vault.hcl
+++ b/vault/vault.hcl
@@ -6,12 +6,12 @@ disable_mlock = false
 
 storage "raft" {
   node_id = "node1"
-  path    = "/vault/data"
+  path    = "/opt/vault/data"
 }
 
 listener "tcp" {
   address       = "127.0.0.1:8200"
   tls_disable   = false
-  tls_cert_file = "/vault/tls/vault.pem"
-  tls_key_file  = "/vault/tls/vault-key.pem"
+  tls_cert_file = "/opt/vault/tls/vault.pem"
+  tls_key_file  = "/opt/vault/tls/vault-key.pem"
 }


### PR DESCRIPTION
### Summary

This PR primarily upgrades Vault to version 2.0, including both the Bootstrapper Vault configured with Podman and the Production Vault running on HA Raft. While the CLI interface remains compatible with Vault 1.x, Vault 2.0 changes the base directory from `/vault/` to `/opt/vault/`.

### Verification

- [x] **Cluster Status**: Verify `vault operator raft list-peers`.
- [x] **Failover**: Verify high availability behavior.
- [x] **VIP Access**: Verify connectivity via Load Balancer/VIP.
- [x] **Idempotency**: Verify repeated execution does not corrupt state.
